### PR TITLE
職業中文化串 (#32)

### DIFF
--- a/data/class/class-barbarian.json
+++ b/data/class/class-barbarian.json
@@ -1,7 +1,7 @@
 {
 	"class": [
 		{
-			"name": "Barbarian",
+			"name": "野蠻人[Barbarian]",
 			"source": "PHB",
 			"hd": {
 				"number": 1,
@@ -195,203 +195,204 @@
 			"classFeatures": [
 				[
 					{
-						"name": "Rage",
+						"name": "狂暴[Rage]",
 						"entries": [
-							"In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action.",
-							"While raging, you gain the following benefits if you aren't wearing heavy armor:",
+							"你帶著原初的狂怒作戰。在你的回合內，你可以使用一個附贈動作進入狂暴。",
+							"在狂暴中，只要你未穿著重甲，就獲得以下好處：",
 							{
 								"type": "list",
 								"items": [
-									"You have advantage on Strength checks and Strength saving throws.",
-									"When you make a melee weapon attack using Strength, you gain a +2 bonus to the damage roll. This bonus increases as you level.",
-									"You have resistance to bludgeoning, piercing, and slashing damage."
+									"你在力量檢定和力量豁免上具有優勢。",
+									"當你進行使用力量的近戰武器攻擊時，你在傷害骰上獲得＋２加值。此加值隨著你的野蠻人等級提升。",
+									"你對鈍擊[bludgeoning]，穿刺[piercing]和揮砍[slashing]傷害具有抗性。"
 								]
 							},
-							"If you are able to cast spells, you can't cast them or concentrate on them while raging.",
-							"Your rage lasts for 1 minute. It ends early if you are knocked {@condition unconscious} or if your turn ends and you haven't attacked a hostile creature since your last turn or taken damage since then. You can also end your rage on your turn as a bonus action.",
-							"Once you have raged the maximum number of times for your barbarian level, you must finish a long rest before you can rage again. You may rage 2 times at 1st level, 3 at 3rd, 4 at 6th, 5 at 12th, and 6 at 17th."
+							"如果你有施法能力，你無法在狂暴下使用法術或專注法術。",
+							"你的狂暴持續１分鐘。如果你陷入昏迷，或是從你上一回合到你這一回合結束都未攻擊任何敵對生物，也未受到傷害，則狂暴提前結束。你也可以在你的回合使用一個附贈動作終止狂暴。",
+							"根據你的野蠻人等級，野蠻人表格中給出了狂暴次數。如果你用光了這些次數，則必須進行一次長休息才能再次使用狂暴。"
 						]
 					},
 					{
-						"name": "Unarmored Defense",
+						"name": "無甲防御[Unarmored Defense]",
 						"entries": [
-							"While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier. You can use a shield and still gain this benefit."
+							"當你未穿著任何盔甲時，你的ＡＣ等於１０＋你的敏捷調整值＋你的體魄調整值。使用盾牌不會影響你從此能力獲益。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Danger Sense",
+						"name": "魯莽攻擊[Reckless Attack]",
 						"entries": [
-							"At 2nd level, you gain an uncanny sense of when things nearby aren't as they should be, giving you an edge when you dodge away from danger. You have advantage on Dexterity saving throws against effects that you can see, such as traps and spells. To gain this benefit, you can't be {@condition blinded}, {@condition deafened}, or {@condition incapacitated}."
-						]
-					},
-					{
-						"name": "Reckless Attack",
-						"entries": [
-							"Starting at 2nd level, you can throw aside all concern for defense to attack with fierce desperation. When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on melee weapon attack rolls using Strength during this turn, but attack rolls against you have advantage until your next turn."
-						]
-					}
-				],
-				[
-					{
-						"name": "Primal Path",
-						"entries": [
-							"At 3rd level, you choose a path that shapes the nature of your rage from the list of available paths. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
-						],
-						"gainSubclassFeature": true
-					}
-				],
-				[
-					{
-						"name": "Ability Score Improvement",
-						"entries": [
-							"When you reach 4th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
-						]
-					}
-				],
-				[
-					{
-						"name": "Extra Attack",
-						"entries": [
-							"Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."
+							"從２級起，你可以拋棄一切防御的執念進行狂亂的攻擊。當你進行回合內第一次攻擊時，你可以選擇采用魯莽攻擊。如果你如此做，你本回合所有使用力量的近戰武器攻擊獲得優勢，但敵人對你的攻擊骰亦獲得優勢。"
 						]
 					},
 					{
-						"name": "Fast Movement",
+						"name": "險境感知[Danger Sense]",
 						"entries": [
-							"Starting at 5th level, your speed increases by 10 feet while you aren't wearing heavy armor."
+							"２級時，你獲得對周遭異常情況超乎尋常的感知能力，讓你能先一步脫離危險。在對抗你可見的效果（如陷阱和法術）影響時，在敏捷豁免上具有優勢。你無法在{@condition 盲目[Blinded]}，{@condition 耳聾[Deafened]}，或是{@condition 乏力[Incapacitated]}的情況下從此能力獲益。"
 						]
 					}
+
 				],
 				[
 					{
-						"name": "Path Feature",
+						"name": "原初道途[Primal Path]",
 						"entries": [
-							"At 6th level, you gain a feature from your Primal Path."
+							"３級時，你選擇一種道途來塑造你狂怒的特質。你可以從狂戰士和圖騰武士兩種道途中選擇一種，詳見後。你在３級，６級，１０級和１４級獲得所選道途的能力。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Feral Instinct",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"By 7th level, your instincts are so honed that you have advantage on initiative rolls.",
-							"Additionally, if you are surprised at the beginning of combat and aren't {@condition incapacitated}, you can act normally on your first turn, but only if you enter your rage before doing anything else on that turn."
+							"當你達到４級時，你可以選擇一項屬性提升２點，或是選擇兩項屬性各提升１點。和通常一樣，你無法通過此能力讓屬性值超過２０。",
+							"如果你的DM允許你使用專長規則，你可以改為得到一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "額外攻擊[Extra Attack]",
 						"entries": [
-							"When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM uses the optional Feats, you can instead take a feat."
+							"從５級起，當你在自己回合進行攻擊動作時，你可以攻擊兩次而非一次。"
+						]
+					},
+					{
+						"name": "快速移動[Fast Movement]",
+						"entries": [
+							"從５級起，只要未穿著重甲，你的速度就獲得１０尺提升。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Brutal Critical (1 die)",
+						"name": "原初道途[Path Feature]",
 						"entries": [
-							"Beginning at 9th level, you can roll one additional weapon damage die when determining the extra damage for a critical hit with a melee attack.",
-							"This increases to two additional dice at 13th level and three additional dice at 17th level."
-						]
-					}
-				],
-				[
-					{
-						"name": "Path feature",
-						"entries": [
-							"At 10th level, you gain a feature from your Primal Path."
+							"６級時，你獲得所選道途的能力。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Relentless Rage",
+						"name": "野性直覺[Feral Instinct]",
 						"entries": [
-							"Starting at 11th level, your rage can keep you fighting despite grievous wounds. If you drop to 0 hit points while you're raging and don't die outright, you can make a DC 10 Constitution saving throw. If you succeed, you drop to 1 hit point instead.",
-							"Each time you use this feature after the first, the DC increases by 5. When you finish a short or long rest, the DC resets to 10."
+							"７級時，你的直覺犀利非常，令你在先攻骰上具有優勢。",
+							"另外，如果戰鬥開始時你被突襲，但並未{@condition 乏力[Incapacitated]}，那麼你可以在你的第一回合正常行動。若你如此做，你必須在進行任何其他行動前進入狂暴。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM uses the optional Feats, you can instead take a feat."
+							"當你達到８級時，你可以選擇一項屬性提升２點，或是選擇兩項屬性各提升１點。和通常一樣，你無法通過此能力讓屬性值超過２０。",
+							"如果你的DM允許你使用專長規則，你可以改為得到一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Brutal Critical (2 dice)",
+						"name": "凶蠻重擊[Brutal Critical] (1 骰)",
 						"entries": [
-							"You now roll two additional weapon damage dice when determining the extra damage for a critical hit with a melee attack."
+							"從９級起，當計算近戰攻擊的重擊傷害時，你可以額外投一次武器傷害骰。",
+							"１３級時，你可以額外投兩次；１７級時，你可以額外投三次。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Path feature",
+						"name": "原初道途[Path Feature]",
 						"entries": [
-							"At 14th level, you gain a feature from your Primal Path."
+							"１０級時，你獲得所選道途的能力。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Persistent Rage",
+						"name": "無情狂暴[Relentless Rage]",
 						"entries": [
-							"Beginning at 15th level, your rage is so fierce that it ends early only if you fall {@condition unconscious} or if you choose to end it."
+							"從１１級起，狂暴的力量讓你即使身受重傷也能持續戰鬥。如果你的生命值降低到０但並未立即死去，你可以通過一次ＤＣ１０的體魄豁免。若豁免成功，則改為你的生命值降低到１。",
+							"在第一次使用此能力後，每當你再次使用此能力，體魄豁免DC增加５。一次短休息或長休息後DC重置為１０。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM uses the optional Feats, you can instead take a feat."
+							"當你達到１２級時，你可以選擇一項屬性提升２點，或是選擇兩項屬性各提升１點。和通常一樣，你無法通過此能力讓屬性值超過２０。",
+							"如果你的DM允許你使用專長規則，你可以改為得到一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Brutal Critical (3 dice)",
+						"name": "凶蠻重擊[Brutal Critical] (2 骰)",
 						"entries": [
-							"You now roll three additional weapon damage dice when determining the extra damage for a critical hit with a melee attack."
+							"現在當你計算近戰攻擊的重擊傷害時，你可以額外投二次武器傷害骰。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Indomitable Might",
+						"name": "原初道途[Path Feature]",
 						"entries": [
-							"Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total."
+							"１４級時，你獲得所選道途的能力。"
+						],
+						"gainSubclassFeature": true
+					}
+				],
+				[
+					{
+						"name": "持久狂暴[Persistent Rage]",
+						"entries": [
+							"從１５級起，你的狂暴是如此強大，以至於只有當你{@condition 昏迷[Unconscious]}或是主動選擇結束狂暴時才會結束。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM uses the optional Feats, you can instead take a feat."
+							"當你達到１６級時，你可以選擇一項屬性提升２點，或是選擇兩項屬性各提升１點。和通常一樣，你無法通過此能力讓屬性值超過２０。",
+							"如果你的DM允許你使用專長規則，你可以改為得到一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Primal Champion",
+						"name": "凶蠻重擊[Brutal Critical] (3 骰)",
 						"entries": [
-							"At 20th level, you embody the power of the wilds. Your Strength and Constitution scores increase by 4. Your maximum for those scores is now 24."
+							"現在當你計算近戰攻擊的重擊傷害時，你可以額外投三次武器傷害骰。"
+						]
+					}
+				],
+				[
+					{
+						"name": "不屈勇武[Indomitable Might]",
+						"entries": [
+							"從１８級起，如果你力量檢定的總值低於你的力量值，你可以用力量值代替檢定的總值。"
+						]
+					}
+				],
+				[
+					{
+						"name": "能力值提升[Ability Score Improvement]",
+						"entries": [
+							"當你達到１９級時，你可以選擇一項屬性提升２點，或是選擇兩項屬性各提升１點。和通常一樣，你無法通過此能力讓屬性值超過２０。",
+							"如果你的DM允許你使用專長規則，你可以改為得到一個專長。"
+						]
+					}
+				],
+				[
+					{
+						"name": "原初勇士[Primal Champion]",
+						"entries": [
+							"２０級時，你的存在就是野性之力的具現。你的力量和體魄各提升４。你這兩項屬性的上限變為２４。"
 						]
 					}
 				]
@@ -403,14 +404,14 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Berserker",
+								"name": "狂戰士道途[Path of the Berserker]",
 								"entries": [
-									"For some barbarians, rage is a means to an end\u2014that end being violence. The Path of the Berserker is a path of untrammeled fury, slick with blood. As you enter the berserker's rage, you thrill in the chaos of battle, heedless of your own health or well-being.",
+									"對某些野蠻人來說，狂暴是達到極致的一種方式，這種極致即是暴力。狂戰士道途是追求鮮血與無拘的狂怒的道路。當你進入狂戰士的狂暴時，你在戰斗的混沌快感中戰栗，舍生忘死般的沖殺。",
 									{
 										"type": "entries",
-										"name": "Frenzy",
+										"name": "狂怒[Frenzy]",
 										"entries": [
-											"Starting when you choose this path at 3rd level, you can go into a frenzy when you rage. If you do so, for the duration of your rage you can make a single melee weapon attack as a bonus action on each of your turns after this one. When your rage ends, you suffer one level of {@condition exhaustion}."
+											"從你選擇此道途的３級起，你可以在狂暴時進入狂怒。如果你如此做，在本回合之後狂暴持續時間內的每個回合，你可以使用一個附贈動作進行一次攻擊。當狂暴結束時，你承受一級{@condition 力竭[Exhaustion]}。"
 										]
 									}
 								]
@@ -421,9 +422,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Mindless Rage",
+										"name": "無我狂暴[Mindless Rage]",
 										"entries": [
-											"Beginning at 6th level, you can't be {@condition charmed} or {@condition frightened} while raging. If you are {@condition charmed} or {@condition frightened} when you enter your rage, the effect is suspended for the duration of the rage."
+											"從６級起，你在狂暴中不會被魅惑或恐慌。如果你開啟狂暴時已經被{@condition 迷惑[Charmed]}或{@condition 恐慌[Frightened]}，則該效果在你狂暴期間被壓制。"
 										]
 									}
 								]
@@ -434,10 +435,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Intimidating Presence",
+										"name": "威懾之姿[Intimidating Presence]",
 										"entries": [
-											"Beginning at 10th level, you can use your action to frighten someone with your menacing presence. When you do so, choose one creature that you can see within 30 feet of you. If the creature can see or hear you, it must succeed on a Wisdom saving throw (DC equal to 8 + your proficiency bonus + your Charisma modifier) or be {@condition frightened} of you until the end of your next turn. On subsequent turns, you can use your action to extend the duration of this effect on the {@condition frightened} creature until the end of your next turn. This effect ends if the creature ends its turn out of line of sight or more than 60 feet away from you.",
-											"If the creature succeeds on its saving throw, you can't use this feature on that creature again for 24 hours."
+											"從１０級起，你可以使用一個動作，以自己可怖的姿態恐嚇他人。選擇一個３０尺內對你可見的生物。如果該生物能看見你或聽見你的聲音，則必須通過一次感知豁免（ＤＣ為８＋你的熟練加值＋你的魅力調整值），否則便對你{@condition 恐慌[Frightened]}，直到你的下一輪結束。在接下來的回合中，你可以使用你的動作延長此效果的持續時間，至你此後一輪結束。如果受影響的生物在你的視覺線外或是６０尺外結束回合，則此效果結束。",
+											"如果生物通過豁免檢定，你無法對這個生物在24小時內再次使用這個特性。"
 										]
 									}
 								]
@@ -448,9 +449,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Retaliation",
+										"name": "復仇[Retaliation]",
 										"entries": [
-											"Starting at 14th level, when you take damage from a creature that is within 5 feet of you. you can use your reaction to make a melee weapon attack against that creature."
+											"從１４級起，當你從５尺內的敵人處受到傷害時，你可以使用你的反應對該生物進行一次近戰武器攻擊。"
 										]
 									}
 								]
@@ -465,31 +466,31 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Totem Warrior",
+								"name": "圖騰武士道途[Path of the Totem Warrior]",
 								"entries": [
-									"The Path of the Totem Warrior is a spiritual journey, as the barbarian accepts a spirit animal as guide, protector, and inspiration. In battle, your totem spirit fills you with supernatural might, adding magical fuel to your barbarian rage.",
-									"Most barbarian tribes consider a totem animal to be kin to a particular clan. In such cases, it is unusual for an individual to have more than one totem animal spirit, though exceptions exist.",
+									"圖騰武士道途是靈魂修煉的旅途。走上此道的野蠻人以一種精魂獸作為他的向導，保護者，和力量源泉。在戰斗中，你的圖騰精魂將超自然的力量灌輸於你，為你的狂暴注入魔法力量。",
+									"大多數野蠻人部落將圖騰獸視為氏族的一員，因此很少有人同時擁有兩種或更多圖騰精魂，盡管這樣的特例依然存在。",
 									{
 										"type": "entries",
-										"name": "Spirit Seeker",
+										"name": "精魂尋者[Spirit Seeker]",
 										"entries": [
-											"Yours is a path that seeks attunement with the natural world, giving you a kinship with beasts. At 3rd level when you adopt this path, you gain the ability to cast the {@spell beast sense} and {@spell speak with animals} spells, but only as rituals, as described in chapter 10."
+											"你追求融入自然之道，與動物為友。在你選擇此道途的３級時，你獲得 {@spell 野獸知覺[Beast Sense]} 和 {@spell 動物交談[Speak with Animals]} 的法術，但只能以儀式施法，詳見第１０章。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Totem Spirit",
+										"name": "圖騰精魂[Totem Spirit]",
 										"entries": [
-											"At 3rd level, when you adopt this path, you choose a totem spirit and gain its feature. You must make or acquire a physical totem object\u2014an amulet or similar adornment\u2014that incorporates fur or feathers, claws, teeth, or bones of the totem animal. At your option, you also gain minor physical attributes that are reminiscent of your totem spirit. For example, if you have a bear totem spirit, you might be unusually hairy and thick-skinned, or if your totem is the eagle, your eyes turn bright yellow.",
-											"Your totem animal might be an animal related to those listed here but more appropriate to your homeland. For example, you could choose a hawk or vulture in place of an eagle.",
+											"在你選擇此道途的３級時，選擇一個圖騰精魂並獲得其能力。你必須制造或獲取一個象征圖騰獸毛，羽，爪，牙或骨的圖騰物件，可以是項鏈，也可以是其他類似的物件。如果你願意，你的外貌也會發生些微改變，讓人看到時不由得聯想起你的圖騰精魂。例如，如果選擇熊的圖騰精魂，你可能變得毛發旺盛，皮膚粗厚；如果選擇鷹的圖騰精魂，你的眼睛可能變成明亮的黃色。",
+											"你圖騰的力量取決於你所選擇的動物，可以選擇下表中的動物，或是其他類似，但更適合你故鄉環境的動物。例如，你可以用鷹或鷲代替雕。",
 											{
 												"type": "entries",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Bear",
+														"name": "熊[Bear]",
 														"entries": [
-															"While raging, you have resistance to all damage except psychic damage. The spirit of the bear makes you tough enough to stand up to any punishment."
+															"狂暴時，你獲得對精神傷害之外任何傷害的抗力。熊之精魂令你堅韌無匹，使你無所畏懼。"
 														]
 													}
 												]
@@ -499,9 +500,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Eagle",
+														"name": "雕[Eagle]",
 														"entries": [
-															"While you're raging and aren't wearing heavy armor, other creatures have disadvantage on opportunity attack rolls against you, and you can use the Dash action as a bonus action on your turn. The spirit of the eagle makes you into a predator who can weave through the fray with ease."
+															"狂暴時，如果你未穿著重甲，則其他生物在對你借機攻擊的攻擊骰上承受劣勢。另外，在你的回合你可以用附贈動作進行疾行動作。雕之精魂讓你成為在戰場中自由穿梭的獵殺者。"
 														]
 													}
 												]
@@ -511,9 +512,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Elk",
+														"name": "狼[Wolf]",
 														"entries": [
-															"While you're raging and aren't wearing heaving armor, your walking speed increases by 15 feet. The spirit of the elk makes you extraordinarily swift."
+															"狂暴時，如果你周圍５尺范圍內有任何敵對生物，則你的盟友對他們的近戰攻擊骰具有優勢。狼之精魂讓你成為獵手中的領袖。"
 														]
 													}
 												]
@@ -523,9 +524,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Tiger",
+														"name": "鹿[Elk](SCAG)",
 														"entries": [
-															"While raging, you can add 10 feet to your long jump distance and 3 feet to your high jump distance. The spirit of the tiger empowers your leaps."
+															"狂暴時，若你未著重甲，你的步行速度增加15尺。鹿之精魂的庇佑使你格外迅捷。"
 														]
 													}
 												]
@@ -535,9 +536,84 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Wolf",
+														"name": "虎[Tiger](SCAG)",
 														"entries": [
-															"While you're raging, your friends have advantage on melee attack rolls against any creature within 5 feet of you that is hostile to you. The spirit of the wolf makes you a leader of hunters."
+															"狂暴時，你增加10尺的跳躍距離和3尺的跳高距離。虎之精魂賦予你飛躍的能力。"
+														]
+													}
+												]
+											}
+
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "獸之形[Aspect of the Beast]",
+										"entries": [
+											"６級時，根據你選擇的圖騰獸，你獲得一項魔法能力。你可以選擇和３級時相同的圖騰，也可以另做選擇。",
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "熊[Bear]",
+														"entries": [
+															"你擁有熊之巨力。你的載重（包括最大負重和最大舉重）翻倍，並且你在推，拉，舉和破壞物體的力量檢定上具有優勢。"
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "雕[Eagle]",
+														"entries": [
+															"你擁有雕之銳目。你可以毫無困難的看到１英裡之內的范圍，細節之處與１００尺以內一樣清晰。另外，你在微光環境中無需承受感知（觀察）檢定上的劣勢。"
+														]
+													}
+												]
+											}
+											,
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "狼[Wolf]",
+														"entries": [
+															"你擁有狼之敏銳。你可以在快速旅行時追蹤其他生物，也可以在正常速度旅行時保持隱秘（旅行速度見第８章）。"
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "鹿[Elk](SCAG)",
+														"entries": [
+															"無論你是騎乘還是徒步，你的旅行速度變為雙倍。只要你未失能，在你周圍60尺內的最多十個同伴也能得到這個好處（參考PHB第八章得到更多有關旅行速度的信息）。鹿的精魂祝福你行得更遠。"
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "虎[Tiger](SCAG)",
+														"entries": [
+															"你從下面列表中選擇兩個技能得到熟練：運動[Athletics]，特技動作[Acrobatics]，隱藏[Stealth]，生存[Survival]。虎之精魂磨練了你的生存本能。"
 														]
 													}
 												]
@@ -552,69 +628,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Aspect of the Beast",
+										"name": "精魂行者[Spirit Walker]",
 										"entries": [
-											"At 6th level, you gain a magical benefit based on the totem animal of your choice. You can choose the same animal you selected at 3rd level or a different one.",
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Bear",
-														"entries": [
-															"You gain the might of a bear. Your carrying capacity (including maximum load and maximum lift) is doubled, and you have advantage on Strength checks made to push, pull, lift, or break objects."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Eagle",
-														"entries": [
-															"You gain the eyesight of an eagle. You can see up to 1 mile away with no difficulty, able to discern even fine details as though looking at something no more than 100 feet away from you. Additionally, dim light doesn't impose disadvantage on your Wisdom (Perception) checks."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Elk",
-														"entries": [
-															"Whether mounted or on foot, your travel pace is doubled, as is the travel pace of up to ten companions while they're within 60 feet of you and you're not {@condition incapacitated}. The elk spirit helps you roam far and fast."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Tiger",
-														"entries": [
-															"You gain proficiency in two skills from the following list: Athletics, Acrobatics, Stealth, and Survival. The cat spirit hones your survival instincts."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Wolf",
-														"entries": [
-															"You gain the hunting sensibilities of a wolf. You can track other creatures while traveling at a fast pace, and you can move stealthily while traveling at a normal pace."
-														]
-													}
-												]
-											}
+											"１０級時，你獲得{@spell 問道自然[Commune with Nature]}的法術，但只能以儀式施法。當你施放此法術時，你選擇的圖騰獸會以精魂形態現身，回答你的疑問。"
 										]
 									}
 								]
@@ -625,30 +641,17 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Spirit Walker",
+										"name": "精魂調諧[Totemic Attunement]",
 										"entries": [
-											"At 10th level, you can cast the {@spell commune with nature} spell, but only as a ritual. When you do so, a spiritual version of one of the animals you chose for Totem Spirit or Aspect of the Beast appears to you to convey the information you seek."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Totemic Attunement",
-										"entries": [
-											"At 14th level, you gain a magical benefit based on a totem animal of your choice. You can choose the same animal you selected previously or a different one.",
+											"１４級時，根據你選擇的圖騰獸，你獲得一項魔法能力。你可以選擇和之前相同的圖騰，也可以另做選擇。",
 											{
 												"type": "entries",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Bear",
+														"name": "熊[Bear]",
 														"entries": [
-															"While you're raging, any creature within 5 feet of you that's hostile to you has disadvantage on attack rolls against targets other than you or another character with this feature. An enemy is immune to this effect if it can't see or hear you or if it can't be {@condition frightened}."
+															"狂暴時，距離你５尺以內任何敵對生物攻擊時，如果他的目標不是你或另一個具有此能力的生物，則他在攻擊骰上承受劣勢。無法看到你或聽到你的聲音的生物以及{@condition 恐慌[Frightened]}的生物對此能力免疫。"
 														]
 													}
 												]
@@ -658,9 +661,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Eagle",
+														"name": "雕[Eagle]",
 														"entries": [
-															"While raging, you have a flying speed equal to your current walking speed. This benefit works only in short bursts; you fall if you end your turn in the air and nothing else is holding you aloft."
+															"狂暴時，你獲得等同於你移動速度的飛行速度。此能力只能用於短途沖刺。如果回合結束時你仍在空中且毫無憑依，你將墜落。"
 														]
 													}
 												]
@@ -670,9 +673,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Elk",
+														"name": "狼[Wolf]",
 														"entries": [
-															"While raging, you can use a bonus action during your move to pass through the space of a Large or smaller creature. That creature must succeed on a Strength saving throw (DC 8 + your Strength bonus + your proficiency bonus) or be knocked {@condition prone} and take bludgeoning damage equal to 1d12 + your strength modifier."
+															"狂暴時，在你的回合，你可以在近戰武器攻擊命中一名大體型或更小的生物時使用一個附贈動作使他{@condition 倒地[Prone]}。"
 														]
 													}
 												]
@@ -682,9 +685,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Tiger",
+														"name": "鹿[Elk](SCAG)",
 														"entries": [
-															"While you're raging, if you move at least 20 feet in a straight line toward a Large or smaller target right before making a melee weapon attack against it, you can use a bonus action to make an additional melee weapon attack against it."
+															"狂暴時，當你試圖穿過一個被大體型或更小的生物占據的空間，你可以使用你的附贈動作讓那個生物立即進行一次力量豁免（DC=8+你的力量調整值+你的熟練值）。若失敗，生物{@condition 倒地[Prone]}並且受到 1d12 + 你的力量調整值 的鈍擊[bludgeoning]傷害。"
 														]
 													}
 												]
@@ -694,9 +697,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Wolf",
+														"name": "虎[Tiger](SCAG)",
 														"entries": [
-															"While you're raging, you can use a bonus action on your turn to knock a Large or smaller creature {@condition prone} when you hit it with melee weapon attack."
+															"狂暴時，如果你向一個大體型或者更小的目標直線接近至少20尺並且向它進行了一次近戰武器攻擊，你可以用附贈動作對它進行一次額外的近戰武器攻擊。"
 														]
 													}
 												]
@@ -715,24 +718,24 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Battlerager",
+								"name": "​戰狂道途[Path of the Battlerager]",
 								"entries": [
-									"Known as Kuldjargh (literally \"axe idiot\") in Dwarvish, battleragers are dwarf followers of the gods of war and take the Path of the Battlerager. They specialize in wearing bulky, {@item spiked armor|scag} and throwing themselves into combat, striking with their body itself and giving themselves over to the fury of battle.",
+									"戰狂道途通常被那些選擇追隨戰爭之神的矮人選擇，在矮人語中他們被稱作為“庫紮爾夫”（意指“斧頭笨蛋”）。他們常穿著厚重的、帶刺的盔甲沖入戰場，用他們自己的身體在戰鬥中揮灑怒火。",
 									{
 										"type": "entries",
-										"name": "Restriction - Dwarves Only",
+										"name": "限制：限定矮人",
 										"entries": [
-											"Only dwarves can follow the Path of the Battlerager. The battlerager fills a particular niche in dwarven society and culture.",
-											"Your DM can lift this restriction to better suit the campaign. The restriction exists for the Forgotten Realms. It might not apply to your DM's setting or your DM's version of the Realms."
+											"只有矮人才可以選擇戰狂道途。在矮人的社會和文化中戰狂占據了一個特殊的位置。",
+											"你的DM可以調整這一規則使之更符合戰役。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Battlerager Armor",
+										"name": "戰狂裝甲[Battlerager Armor]",
 										"entries": [
-											"When you choose this path at 3rd level, you gain the ability to use {@item spiked armor|scag} as a weapon.",
-											"While you are wearing {@item spiked armor|scag} and are raging, you can use a bonus action to make one melee weapon attack with your armor spikes at a target within 5 feet of you. If the attack hits, the spikes deal 1d4 piercing damage. You use your Strength modifier for the attack and damage rolls.",
-											"Additionally, when you use the Attack action to grapple a creature, the target takes 3 piercing damage if your grapple check succeeds."
+											"從3級起，你得到將{@item 釘刺甲[spiked armor]|scag}（參照“釘刺甲”邊欄）作為武器使用的能力。",
+											"當你穿著{@item 釘刺甲[spiked armor]|scag}並在狂暴中，你可以使用你的附贈動作用釘刺甲對5尺內的目標進行一次近戰武器攻擊。若攻擊命中，釘刺將造成1d4的穿刺傷害。把你的力量調整加在武器的攻擊和傷害骰上。",
+											"另外，當你使用攻擊動作去擒抱一個生物，你在擒抱檢定成功時對他造成3點穿刺傷害。"
 										]
 									}
 								]
@@ -743,9 +746,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Reckless Abandon",
+										"name": "​兇蠻無羈[Reckless Abandon]",
 										"entries": [
-											"Beginning at 6th level, when you use Reckless Attack while raging, you also gain temporary hit points equal to your Constitution modifier (minimum of 1). They vanish if any of them are left when your rage ends."
+											"從6級起，若你在狂暴中使用魯莽攻擊，你可以增加等同你體質調整值的臨時生命（最少1點）。當你結束狂暴時它們消失。"
 										]
 									}
 								]
@@ -756,9 +759,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Battlerager Charge",
+										"name": "戰狂沖鋒[Battlerager Charge]",
 										"entries": [
-											"Beginning at 10th level, you can take the Dash action as a bonus action while you are raging."
+											"從10級起，你在狂暴中可以用一個附贈動作進行疾走。"
 										]
 									}
 								]
@@ -769,9 +772,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Spiked Retribution",
+										"name": "釘刺反沖[Spiked Retribution]",
 										"entries": [
-											"Starting at 14th level, when a creature within 5 feet of you hits you with a melee attack, the attacker takes 3 piercing damage if you are raging, aren't {@condition incapacitated}, and are wearing {@item spiked armor|scag}."
+											"從14級起，每當你5尺內有生物用近戰攻擊命中你，同時你處於狂暴中且並非{@condition 乏力[Incapacitated]}，攻擊者將立即受到 3 點穿刺[piercing]傷害。你必須穿著{@item 釘刺甲[spiked armor]|scag}才能使用這個能力。"
 										]
 									}
 								]
@@ -782,386 +785,19 @@
 					"shortName": "Battlerager"
 				},
 				{
-					"name": "Path of the Ancestral Guardian (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Path of the Ancestral Guardian",
-								"entries": [
-									"Some barbarians hail from cultures that revere their ancestors. These tribes teach that the warriors of the past linger on in the world as mighty spirits who can guide and protect the living. When barbarians who follow this path rage, they cross the barrier into the spirit world and call on these guardian spirits for aid.",
-									"Barbarians who draw on their ancestral guardians fight to protect their tribes and their allies. With the spirits' help, they can hinder their foes even as they strike powerful blows against them.",
-									"In order to cement ties to their ancestral guardians, barbarians who follow this path cover themselves in elaborate tattoos that celebrate their ancestors' deeds. These tattoos tell epic sagas of victories against terrible monsters and other fearsome rivals.",
-									{
-										"type": "entries",
-										"name": "Ancestral Protectors",
-										"entries": [
-											"Starting when you choose this path at 3rd level, spectral warriors appear when you rage. These warriors distract a foe you designate and hinder its attempts to evade you. While you're raging, you can use a bonus action on your turn to choose one creature you can see within 5 feet of you. Until the start of your next turn or until your rage ends, the chosen creature has disadvantage on any attack roll that doesn't target you, and if the creature takes the Disengage action within 5 feet of you, its speed is halved until the end of its turn."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Ancestral Shield",
-										"entries": [
-											"Beginning at 6th level, the guardian spirits that aid you can provide protection for your allies. If you are raging and an ally you can see within 30 feet of you takes bludgeoning, piercing, or slashing damage, you can use your reaction to transfer your resistance to those damage types to the ally. The resistance applies to the incoming damage. Until the start of your next turn, the ally keeps the resistance and you lack it, unless you also have it from a source other than rage."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Consult the Spirits",
-										"entries": [
-											"At 10th level, you gain the ability to consult with your ancestral spirits. Right before you make an Intelligence or a Wisdom check, you can give yourself advantage on the check. You can use this feature three times, and you regain expended uses when you finish a long rest."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Vengeful Ancestors",
-										"entries": [
-											"At 14th level, your ancestral spirits grow powerful enough to strike your foes. When you or an ally you can see within 30 feet of you is damaged by a melee attack while you're raging, you can use your reaction to cause the attacker to take 2d8 force damage from the spirits."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UABarbarianPrimalPaths",
-					"shortName": "Ancestral Guardian (UA)"
-				},
-				{
-					"name": "Path of the Ancestral Guardian v2 (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Path of the Ancestral Guardian v2",
-								"entries": [
-									"Some barbarians hail from cultures that revere their ancestors. These tribes teach that the warriors of the past linger on in the world as mighty spirits who can guide and protect the living. When barbarians who follow this path rage, they cross the barrier into the spirit world and call on these guardian spirits for aid.",
-									"Barbarians who draw on their ancestral guardians fight to protect their tribes and their allies. With the spirits' help, they can hinder their foes even as they strike powerful blows against them.",
-									"In order to cement ties to their ancestral guardians, barbarians who follow this path cover themselves in elaborate tattoos that celebrate their ancestors' deeds. These tattoos tell epic sagas of victories against terrible monsters and other fearsome rivals.",
-									{
-										"type": "entries",
-										"name": "Ancestral Protectors",
-										"entries": [
-											"Starting when you choose this path at 3rd level, spectral warriors appear when you rage. These warriors distract a foe you designate and hinder its attempts to evade you. While you're raging, the first creature you hit with an attack on your turn becomes the target of these warriors. Until the start of your next turn or until your rage ends, that target has disadvantage on any attack roll that doesn't target you, and creatures other than you have resistance to the damage of the creature's attacks."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Ancestral Shield",
-										"entries": [
-											"Beginning at 6th level, the guardian spirits that aid you can provide protection for your allies. If you are raging and a creature you can see within 30 feet of you takes damage, you can use your reaction and reduce that damage by 2d8. When you reach certain levels in this class, you can reduce the damage by more: by 3d8 at 10th level and by 4d8 at 14th level."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Consult the Spirits",
-										"entries": [
-											"At 10th level, you gain the ability to consult with your ancestral spirits and use them to scout far-off lands. When you do so, you cast the {@spell clairvoyance} spell, without needing a spell slot. Rather than creating a spherical sensor, the spell invisibly summons one of your ancestral spirits to the chosen location. Wisdom is your spellcasting ability for the spell. After you cast the spell in this way, you can't do so again until you finish a short or long rest."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Vengeful Ancestors",
-										"entries": [
-											"At 14th level, your ancestral spirits grow powerful enough to strike foes that dare harm those that you protect. When you use your Spirit Shield Ability to protect a creature damaged by an attack, the attacker takes the same amount of damage that the Spirit Shield protects."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UARevisedSubclasses",
-					"shortName": "Ancestral Guardian v2 (UA)"
-				},
-				{
-					"name": "Path of the Storm Herald (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Path of the Storm Herald",
-								"entries": [
-									"Typical barbarians harbor a fury that dwells within. Their rage grants them superior strength, durability, and speed. Barbarians who follow the Path of the Storm Herald learn instead to transform their rage into a mantle of primal magic that swirls around them. When in a fury, a barbarian of this path taps into nature to create powerful, magical effects.",
-									"Storm heralds are typically elite champions who train alongside druids, rangers, and others sworn to protect the natural realm. Other storm heralds hone their craft in elite lodges founded in regions wracked by storms, in the frozen reaches at the world's end, or deep in the hottest deserts.",
-									{
-										"type": "entries",
-										"name": "Storm of Fury",
-										"entries": [
-											"When you select this path at 3rd level, choose one of the following options: desert, sea, or tundra. The environment you choose shapes the nature of the storm you conjure when you rage. While raging, you emanate an aura in a 10-foot radius. The effects of this aura depend on your chosen environment.",
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Desert",
-														"entries": [
-															"Any enemy that ends its turn in your aura takes fire damage equal to 2 + your barbarian level divided by 4."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Sea",
-														"entries": [
-															"At the end of each of your turns, you can choose a creature in your aura other than yourself. The target must make a Dexterity saving throw against a DC equal to 8 + your proficiency bonus + your Constitution modifier. The target takes 2d6 lightning damage on a failed save, and half as much damage on a successful one. This damage increases to 3d6 at 10th level and to 4d6 at 15th level."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Tundra",
-														"entries": [
-															"Any enemy that ends its turn in your aura takes cold damage equal to 2 + your barbarian level divided by 4."
-														]
-													}
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Storm Soul",
-										"entries": [
-											"At 6th level, your link to the power of the storm grants you additional abilities based on the environment you chose at 3rd level.",
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Desert",
-														"entries": [
-															"You gain resistance to fire damage and don't suffer the effects of extreme heat."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Sea",
-														"entries": [
-															"You gain resistance to lightning damage and can breathe underwater."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Tundra",
-														"entries": [
-															"Tundra. You gain resistance to cold damage and don't suffer the effects of extreme cold."
-														]
-													}
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Shield of the Storm",
-										"entries": [
-											"At 10th level, you learn to use your mastery of the storm to protect your allies. While you are raging, allies within your aura gain the benefits of your Storm Soul feature."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Raging Storm",
-										"entries": [
-											"At 14th level, the power of the storm you channel grows mightier.",
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Desert",
-														"entries": [
-															"The ground around you becomes like shifting sand. Any enemy that attempts to move more than 5 feet per turn on the ground while in your aura must make a Strength saving throw (DC 8 + your proficiency bonus + your Constitution modifier). On a failed save, the creature's speed drops to 0 until the start of its next turn."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Sea",
-														"entries": [
-															"Roaring winds tear through the area around you. Any creature in your aura that you hit with an attack must make a Strength saving throw (DC 8 + your proficiency bonus + your Strength modifier) or be knocked {@condition prone}."
-														]
-													}
-												]
-											},
-											{
-												"type": "entries",
-												"entries": [
-													{
-														"type": "entries",
-														"name": "Tundra",
-														"entries": [
-															"The air around you coldly slows your foes. The area within your aura is difficult terrain for your enemies."
-														]
-													}
-												]
-											}
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UABarbarianPrimalPaths",
-					"shortName": "Storm Herald (UA)"
-				},
-				{
-					"name": "Path of the Zealot (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Path of the Zealot",
-								"entries": [
-									"Some deities inspire their followers to pitch themselves into a ferocious battle fury. These barbarians are zealots\u2014warriors who channel their rage into powerful displays of divine power.",
-									"A variety of gods across the worlds of D&D inspire their followers to embrace this path. Tempus from the Forgotten Realms and Hextor and Erythnul of Greyhawk are all prime examples. In general, the gods who inspire zealots are deities of combat, destruction, and violence. Not all are evil, but few are good.",
-									{
-										"type": "entries",
-										"name": "Divine Fury",
-										"entries": [
-											"Starting when you choose this path at 3rd level, you can channel divine fury when you start to rage. If you do so, you become cloaked in an aura of divine power until the rage ends. At the end of each of your turns for that duration, each creature within 5 feet of you takes damage equal to 1d6 + half your barbarian level. The damage is necrotic or radiant; you choose the type of damage when you gain this feature."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Warrior of the Gods",
-										"entries": [
-											"At 3rd level, your soul is marked for endless battle. If a spell would have the sole effect of restoring you to life (but not undeath), the caster does not need material components to cast the spell on you."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Zealous Focus",
-										"entries": [
-											"At 6th level, the divine power that fuels your rage can shield you from harm. If you fail a saving throw while raging, you can instead succeed on that saving throw as a reaction. However, doing so immediately ends your rage, and you can't rage again until you finish a short or long rest."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Zealous Presence",
-										"entries": [
-											"At 10th level, you learn to channel divine power to inspire zealotry in others. As an action, you howl in fury and unleash a battle cry infused with divine energy. Every ally within 60 feet of you gains advantage on attack rolls and saving throws until the start of your next turn.",
-											"Once you use this feature, you can't use it again until you finish a long rest."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Rage Beyond Death",
-										"entries": [
-											"Beginning at 14th level, the divine power that fuels your rage allows you to shrug off fatal blows.",
-											"While raging, having 0 hit points doesn't knock you {@condition unconscious}. You still must make death saving throws, and you suffer the normal effects of taking damage while at 0 hit points. However, if you would die due to failing death saving throws, you don't die until your rage ends."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UABarbarianPrimalPaths",
-					"shortName": "Zealot (UA)"
-				},
-				{
 					"name": "Path of the Ancestral Guardian",
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Ancestral Guardian",
+								"name": "先祖守衛之途[Path of the Ancestral Guardian]",
 								"entries": [
-									"Some barbarians hail from cultures that revere their ancestors. These tribes teach that the warriors of the past linger in the world as mighty spirits, who can guide and protect the living. When a barbarian who follows this path rages, the barbarian contacts the spirit world and calls on these guardian spirits for aid.",
-									"Barbarians who draw on their ancestral guardians can better fight to protect their tribes and their allies. In order to cement ties to their ancestral guardians, barbarians who follow this path cover themselves in elaborate tattoos that celebrate their ancestors' deeds. These tattoos tell sagas of victories against terrible monsters and other fearsome rivals.",
+									"一些野蠻人來自敬畏祖先的文化。這些部落告訴我們，過去的勇士們作為強大的靈魂在世界上徘徊，他們能夠引導和保護活著的人。當一個野蠻人沿著這條路狂怒時，野蠻人就會接觸精神世界，並向這些守護精神尋求幫助。",
+									"運用先祖守護的野蠻人可以更好地戰鬥以保護他們的部落和盟友。為了加強與祖先的守護者的聯繫，遵循這條道路的野蠻人會在身上紋上精緻的紋身來紀念他們祖先的功績。這些紋身講述了戰勝可怕的怪物和其他可怕的對手的傳奇故事。",
 									{
 										"type": "entries",
-										"name": "Ancestral Protectors",
+										"name": "先祖守護[Ancestral Protectors]",
 										"entries": [
-											"Starting when you choose this path at 3rd level, spectral warriors appear when you enter your rage. While you're raging, the first creature you hit with an attack on your turn becomes the target of the warriors, which hinder its attacks. Until the start of your next turn, that target has disadvantage on any attack roll that isn't against you, and when the target hits a creature other than you with an attack, that creature has resistance to the damage dealt by the attack. The effect on the target ends early if your rage ends."
+											"從你在3級時選擇此道途開始，精魂戰士會在你狂暴時出現。當你處於狂暴狀態，你的回合內你攻擊命中的第一個生物會成為戰士的目標。直到你的下一個回合開始，目標對你以外的目標的攻擊骰取劣勢，若目標在一次攻擊中擊中了除你以外的生物，該生物對那次攻擊有傷害抗力。若你的狂暴結束，此效果也隨之提前結束。"
 										]
 									}
 								]
@@ -1172,10 +808,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Spirit Shield",
+										"name": "精魂之盾[Spirit Shield]",
 										"entries": [
-											"Beginning at 6th level, the guardian spirits that aid you can provide supernatural protection to those you defend. If you are raging and another creature you can see within 30 feet of you takes damage, you can use your reaction to reduce that damage by 2d6.",
-											"When you reach certain levels in this class, you can reduce the damage by more: by 3d6 at 10th level and by 4d6 at 14th level."
+											"從6級開始，衛士之魂會幫助你為你的盟友提供超自然保護。若你處於狂暴，而一個處於你周圍30英尺內的，你能看到的其他生物受到傷害，你可以用一個反應動作來降低2d6的傷害。",
+											"當你達到這一範型的更高等級，你可以防止更多的傷害：10級3d6，14級4d6。"
 										]
 									}
 								]
@@ -1186,10 +822,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Consult the Spirits",
+										"name": "問道精魂[Consult the Spirits]",
 										"entries": [
-											"At 10th level, you gain the ability to consult with your ancestral spirits. When you do so, you cast the {@spell augury} or {@spell clairvoyance} spell, without using a spell slot or material components. Rather than creating a spherical sensor, this use of {@spell clairvoyance} invisibly summons one of your ancestral spirits to the chosen location. Wisdom is your spellcasting ability for these spells.",
-											"After you cast either spell in this way, you can't use this feature again until you finish a short or long rest."
+											"在10級時，你得到和你的先祖之魂進行交流的能力。當你使用此能力，你可以不消耗法術位和材料成分使用一次 {@spell 卜筮[Augury]} 或 {@spell 鷹眼術[Clairvoyance]}。這個法術會在指定位置創造一個無形的先祖之魂，取代法術描述裏的球形探測器。感知是你的施法主屬性。",
+											"使用此能力施法後，直到短休息或者長休息你才可以重新使用。"
 										]
 									}
 								]
@@ -1200,9 +836,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Vengeful Ancestors",
+										"name": "先祖復仇[Vengeful Ancestors]",
 										"entries": [
-											"At 14th level, your ancestral spirits grow powerful enough to retaliate. When you use your Spirit Shield to reduce the damage of an attack, the attacker takes an amount of force damage equal to the damage that your Spirit Shield prevents."
+											"在14級時，你的先祖之魂變得強大到足以打擊傷害你所保護之人的敵人。當你使用精魂之盾保護生物、降低一次攻擊的傷害時，攻擊者受到精魂之盾所降低的等量力場[force]傷害。"
 										]
 									}
 								]
@@ -1217,39 +853,39 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Storm Herald",
+								"name": "風暴先驅道途[Path of the Storm Herald]",
 								"entries": [
-									"All barbarians harbor a fury within. Their rage grants them superior strength, durability, and speed. Barbarians who follow the Path of the Storm Herald learn to transform that rage into a mantle of primal magic, which swirls around them. When in a fury, a barbarian of this path taps into the forces of nature to create powerful magical effects.",
-									"Storm heralds are typically elite champions who train alongside druids, rangers, and others sworn to protect nature. Other storm heralds hone their craft in lodges in regions wracked by storms, in the frozen reaches at the world's end, or deep in the hottest deserts.",
+									"所有的野蠻人內心都藏著怒火。他們的憤怒賦予他們卓越的力量、耐久性和速度。追隨風暴使者之路的野蠻人學會了將憤怒轉化為原始魔法的外衣，並在他們周圍盤旋。當憤怒的時候，這條路的野蠻人利用自然的力量創造強大的魔法效果。",
+									"風暴先驅通常是一群精英，他們與德魯伊、遊騎兵和其他發誓保護自然的人一起訓練。其他的風暴先驅們通常會在被風暴破壞的地區、世界盡頭的冰凍地帶、或者在最炎熱的沙漠深處磨練自己的技藝。",
 									{
 										"type": "entries",
-										"name": "Storm Aura",
+										"name": "風暴靈光[Storm Aura]",
 										"entries": [
-											"Starting at 3rd level, you emanate a stormy, magical aura while you rage. The aura extends 10 feet from you in every direction, but not through total cover.",
-											"Your aura has an effect that activates when you enter your rage, and you can activate the effect again on each of your turns as a bonus action. Choose desert, sea, or tundra. Your aura's effect depends on that chosen environment, as detailed below. You can change your environment choice whenever you gain a level in this class.",
-											"If your aura's effects require a saving throw, the DC equals 8 + your proficiency bonus + your Constitution modifier.",
+											"當你在3級選擇此道途時，當處於狂暴時，你散發出一個10英尺半徑的靈光，但無法穿透全掩護。",
+											"你的靈光效果擁有一個由你進入狂暴時所激活的效果，你在每個自己的回合也可以用一個附贈動作來激活該效果。從下述選項中選擇一個：沙漠，海洋，或凍原，此靈光的效果基於你選擇的環境類型。每當你在此職業中獲得級別提升時，你可以改變所選環境。",
+											"如果你的光環效果需要進行豁免，DC等於8+你的熟練加值+你的體質調整。",
 											{
 												"type": "options",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Desert",
+														"name": "沙漠[Desert]",
 														"entries": [
-															"When this effect is activated, all other creatures in your aura take 2 fire damage each. The damage increases when you reach certain levels in this class, increasing to 3 at 5th level, 4 at 10th level, 5 at 15th level, and 6 at 20th level."
+															"當這個效果被激活時，你的靈光中所有其他生物都會受到2點火焰傷害。當你在這個職業達到一定等級時，傷害增加——在5級時增加到3，10級時增加到4，15級時增加到5，20級時增加到6。"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Sea",
+														"name": "海洋[Sea]",
 														"entries": [
-															"When this effect is activated, you can choose one other creature you can see in your aura. The target must make a Dexterity saving throw. The target takes 1d6 lightning damage on a failed save, or half as much damage on a successful one. The damage increases when you reach certain levels in this class, increasing to 2d6 at 10th level, 3d6 at 15th level, and 4d6 at 20th level."
+															"當這個效果被激活時，你可以選擇一個處於靈光中且你能看到的其他生物。目標必須通過一個敏捷豁免，否則受到1d6閃電傷害，豁免成功則傷害減半。當你在這個職業達到一定等級時，傷害增加——10級增加到2d6，15級增加到3d6，20級增加到4d6。​"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Tundra",
+														"name": "凍原[Tundra]",
 														"entries": [
-															"When this effect is activated, each creature of your choice in your aura gains 2 temporary hit points, as icy spirits inure it to suffering. The temporary hit points increase when you reach certain levels in this class, increasing to 3 at 5th level, 4 at 10th level, 5 at 15th level, and 6 at 20th level."
+															"當這個效果被激活時，靈光中每個你選擇的生物獲得2點臨時生命，這是因為寒冰精魂使它習慣於受苦。當你在這個職業達到一定等級時，臨時生命增加——在5級時增加到3，10級時增加到4，15級時增加到5，20級時增加到6。"
 														]
 													}
 												]
@@ -1264,31 +900,31 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Storm Soul",
+										"name": "風暴之魂[Storm Soul]",
 										"entries": [
-											"At 6th level, the storm grants you benefits even when your aura isn't active. The benefits are based on the environment you chose for your Storm Aura.",
+											"在6級時，風暴在你不激活靈光時也能給你帶來增益。增益效果基於你選擇風暴靈光的環境類型。",
 											{
 												"type": "options",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Desert",
+														"name": "沙漠[Desert]",
 														"entries": [
-															"You gain resistance to fire damage, and you don't suffer the effects of extreme heat, as described in the Dungeon Master's Guide. Moreover, as an action, you can touch a flammable object that isn't being worn or carried by anyone else and set it on fire."
+															"你得到對火焰[fire]傷害的抗性，並不會受到極端高溫的效果影響（見城主手冊）。此外，以一個動作，你可以觸摸一個沒有被他人穿戴或攜帶的易燃物體，並且點燃它。"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Sea",
+														"name": "海洋[Sea]",
 														"entries": [
-															"You gain resistance to lightning damage, and you can breathe underwater. You also gain a swimming speed of 30 feet."
+															"你得到對閃電[lightning]傷害的抗性，並能在水下呼吸。你還獲得了30尺的遊泳速度。"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Tundra",
+														"name": "凍原[Tundra]",
 														"entries": [
-															"You gain resistance to cold damage, and you don't suffer the effects of extreme cold, as described in the Dungeon Master's Guide. Moreover, as an action, you can touch water and turn a 5-foot cube of it into ice, which melts after 1 minute. This action fails if a creature is in the cube."
+															"得到對寒冷[cold]傷害的抗性，並不會受到極端低溫的效果影響（見城主手冊）。此外，以一個動作，你可以觸摸水並且把5立方英尺的水凍結成冰，這種冰將會在1分鐘後融化。如果有生物處於該立方空間中，你的行動將會失敗。"
 														]
 													}
 												]
@@ -1303,9 +939,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Shielding Storm",
+										"name": "風暴之盾[Shielding Storm]",
 										"entries": [
-											"At 10th level, you learn to use your mastery of the storm to protect others. Each creature of your choice has the damage resistance you gained from the Storm Soul feature while the creature is in your Storm Aura."
+											"在10級時，你學會了運用你的風暴的掌控力來保護你的盟友。處於你靈光內的、你選擇的生物得到你的風暴之魂特性所帶來的傷害抗性。"
 										]
 									}
 								]
@@ -1316,31 +952,31 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Raging Storm",
+										"name": "狂怒風暴[Raging Storm]",
 										"entries": [
-											"At 14th level, the power of the storm you channel grows mightier, lashing out at your foes. The effect is based on the environment you chose for your Storm Aura.",
+											"在14級時，你能引導的風暴之力變得更加強大，足以打擊你的敵人。效果基於你為風暴靈光選擇的環境類型。",
 											{
 												"type": "options",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Desert",
+														"name": "沙漠[Desert]",
 														"entries": [
-															"Immediately after a creature in your aura hits you with an attack, you can use your reaction to force that creature to make a Dexterity saving throw. On a failed save, the creature takes fire damage equal to half your barbarian level."
+															"當處於你靈光中的生物在一次攻擊命中你後，你可以用你的反應迫使該生物立刻做一次敏捷豁免。豁免失敗則受到等於你野蠻人等級一半數值的火焰傷害。"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Sea",
+														"name": "海洋[Sea]",
 														"entries": [
-															"When you hit a creature in your aura with an attack, you can use your reaction to force that creature to make a Strength saving throw. On a failed save, the creature is knocked {@condition prone}, as if struck by a wave."
+															"任何處於你靈光中的生物若被你以一次攻擊擊中，你可以用你的反應迫使該生物進行一次力量豁免，否則如同被波浪拍打般被擊倒在地，變為{@condition 倒地[Prone]}狀態。"
 														]
 													},
 													{
 														"type": "entries",
-														"name": "Tundra",
+														"name": "凍原[Tundra]",
 														"entries": [
-															"Whenever the effect of your Storm Aura is activated, you can choose one creature you can see in the aura. That creature must succeed on a Strength saving throw, or its speed is reduced to 0 until the start of your next turn, as magical frost covers it."
+															"每當你的風暴靈光激活時，你可以選擇一個你可以看見的、處於靈光裏的生物。該生物必須通過一次力量檢定，否則其速度降為0，直到你的下一個回合開始，如同魔法的冰霜凍結了它。"
 														]
 													}
 												]
@@ -1359,22 +995,22 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Path of the Zealot",
+								"name": "狂熱道途[Path of the Zealot]",
 								"entries": [
-									"Some deities inspire their followers to pitch themselves into a ferocious battle fury. These barbarians are zealots\u2014warriors who channel their rage into powerful displays of divine power.",
-									"A variety of gods across the worlds of D&D inspire their followers to embrace this path. Tempus from the Forgotten Realms and Hextor and Erythnul of Greyhawk are all prime examples. In general, the gods who inspire zealots are deities of combat, destruction, and violence. Not all are evil, but few are good.",
+									"一些神靈激勵他們的追隨者們投身於殘酷的戰鬥狂怒中。這些野蠻人是狂熱的戰士，他們引導自己的憤怒轉化為強大的神賜力量。",
+									"在DND世界中有許多神祇都會鼓勵自己的追隨者尋求狂熱者道途。最著名的是費倫的Tempus，以及灰鷹的海克斯托（Hextor）和Erythnul。一般來說，那些培養狂熱者的神祇往往是偏向於戰鬥、破壞和暴力等神職。當然，不是所有（這樣的）神都是邪惡，但只有少數是例外。",
 									{
 										"type": "entries",
-										"name": "Divine Fury",
+										"name": "神性之怒[Divine Fury]",
 										"entries": [
-											"Starting when you choose this path at 3rd level, you can channel divine fury into your weapon strikes. While you're raging, the first creature you hit on each of your turns with a weapon attack takes extra damage equal to 1d6 + half your barbarian level. The extra damage is necrotic or radiant; you choose the type of damage when you gain this feature."
+											"從你在3級選擇此道途開始，你可以引導神性之怒註入武器打擊中。當你處於狂暴中，你在自己回合中用武器攻擊命中的第一個生物會受到額外傷害，數值等於1d6+你野蠻人等級的一半。此傷害的類型為黯蝕[necrotic]或光耀[radiant]；你在你得到此特性時選擇它的類型。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Warrior of the Gods",
+										"name": "神之勇者[Warrior of the Gods]",
 										"entries": [
-											"At 3rd level, your soul is marked for endless battle. If a spell, such as {@spell raise dead}, has the sole effect of restoring you to life (but not undeath), the caster doesn't need material components to cast the spell on you."
+											"在3級時，你的靈魂被無盡的戰鬥所烙印。若一個法術（例如死者復活）——只具有讓你起死回生（但不能是不死生物）的效果，該施法者在對你施展法術時不需要材料成分。"
 										]
 									}
 								]
@@ -1385,9 +1021,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Fanatical Focus",
+										"name": "狂熱專注[Fanatical Focus]",
 										"entries": [
-											"Starting at 6th level, the divine power that fuels your rage can protect you. If you fail a saving throw while you're raging, you can reroll it, and you must use the new roll. You can use this ability only once per rage."
+											"在6級時，驅使你憤怒的神力也能庇護你免遭損害。若你在狂暴時未通過一次豁免檢定，你可以重新投擲該豁免檢定，但你必須接受第二次投擲的數值。你每次狂暴只能使用此能力一次。"
 										]
 									}
 								]
@@ -1398,10 +1034,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Zealous Presence",
+										"name": "狂熱存在[Zealous Presence]",
 										"entries": [
-											"At 10th level, you learn to channel divine power to inspire zealotry in others. As a bonus action, you unleash a battle cry infused with divine energy. Up to ten other creatures of your choice within 60 feet of you that can hear you gain advantage on attack rolls and saving throws until the start of your next turn.",
-											"Once you use this feature, you can't use it again until you finish a long rest."
+											"在10級時，你學會了引導神力，讓其他人也被狂熱所感染。以一個附贈動作，你憤怒的怒吼並釋放出一道蘊含神聖能量的戰吼。選擇至多10個距離你60尺以內並且能聽到你吼叫的其他生物，直到你的下個回合開始，在攻擊檢定和豁免檢定中獲得優勢。",
+											"一旦你使用了此特性，你不能再次使用它，直到你完成了一次長休息。"
 										]
 									}
 								]
@@ -1412,10 +1048,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Rage beyond Death",
+										"name": "怒不畏死[Rage beyond Death]",
 										"entries": [
-											"Beginning at 14th level, the divine power that fuels your rage allows you to shrug off fatal blows.",
-											"While you're raging, having 0 hit points doesn't knock you {@condition unconscious}. You still must make death saving throws, and you suffer the normal effects of taking damage while at 0 hit points. However, if you would die due to failing death saving throws, you don't die until your rage ends, and you die then only if you still have 0 hit points."
+											"從14級開始，驅使你狂暴的神力允許你忽視致命的打擊。",
+											"當處於狂暴時，具有0點生命值不會讓你{@condition 昏迷[Unconscious]}。你仍然必須進行死亡豁免檢定，而你在0生命值下受到傷害時承受正常的效果。但是，若你因為未通過死亡豁免檢定而即將死去，你拒絕死亡直到你的狂暴結束，如果你狂暴結束時還是0生命值你直接死亡。"
 										]
 									}
 								]

--- a/data/class/class-bard.json
+++ b/data/class/class-bard.json
@@ -1,7 +1,7 @@
 {
 	"class": [
 		{
-			"name": "Bard",
+			"name": "吟遊詩人[Bard]",
 			"source": "PHB",
 			"hd": {
 				"number": 1,
@@ -388,47 +388,47 @@
 			"classFeatures": [
 				[
 					{
-						"name": "Bardic Inspiration",
+						"name": "吟遊激勵[Bardic Inspiration]",
 						"entries": [
-							"You can inspire others through stirring words or music. To do so, you use a bonus action on your turn to choose one creature other than yourself within 60 feet of you who can hear you. That creature gains one Bardic Inspiration die, a d6.",
-							"Once within the next 10 minutes, the creature can roll the die and add the number rolled to one ability check, attack roll, or saving throw it makes. The creature can wait until after it rolls the d20 before deciding to use the Bardic Inspiration die, but must decide before the DM says whether the roll succeeds or fails. Once the Bardic Inspiration die is rolled, it is lost. A creature can have only one Bardic Inspiration die at a time.",
-							"You can use this feature a number of times equal to your Charisma modifier (a minimum of once). You regain any expended uses when you finish a long rest.",
-							"Your Bardic Inspiration die changes when you reach certain levels in this class. The die becomes a d8 at 5th level, a d10 at 10th level, and a d12 at 15th level."
+							"你使用你的詩詞以及音樂來賜給他人靈感。這能力適用於你的附贈行動中，60尺之內的一種生物，那生物追加一個吟遊激勵骰，d6。",
+							"這生物在10分鐘內能夠在能力值檢定、攻擊檢定或赦免檢定使用一次d6遊激勵骰。這生物可在骰d20之後做這決定，這也只能在DM的成功或失敗判定前做這決定。",
+							"使用吟遊激勵骰後，此骰就不能在使用(一個生物只能有一顆骰)。這能力使用的數量為你的魅力加值(最小值是1次)。使用完後需要長休來回充吟遊靈感。",
+							"吟遊激勵骰會因等級調升，5 等 d8 、 10 等 d10 、 15 等 d12。"
 						]
 					},
 					{
-						"name": "Spellcasting",
+						"name": "​施法[Spellcasting]",
 						"entries": [
-							"You have learned to untangle and reshape the fabric of reality in harmony with your wishes and music. Your spells are part of your vast repertoire, magic that you can tune to different situations. See chapter 10 for the general rules of spellcasting and chapter 11 for the bard spell list.",
+							"你習得用音樂和意志來解構、分解、再構造現實的力量。你的法術是你複雜指令的一部分，可以進行調諧來適應各種情況。具體請參見第十章尋求基本施法規則，參閱第十一章的吟遊詩人法術列表。",
 							{
 								"type": "entries",
-								"name": "Cantrips",
+								"name": "戲法[Cantrips]",
 								"entries": [
-									"You know two cantrips of your choice from the bard spell list. You learn additional bard cantrips of your choice at higher levels, learning a 3rd cantrip at 4th level and a 4th at 10th level."
+									"你獲得2項小法術，從吟遊詩人法術列表選擇。隨著你升級你將學會自選的額外吟遊詩人小法術，如吟遊詩人法術表所示。"
 								]
 							},
 							{
 								"type": "entries",
-								"name": "Spell Slots",
+								"name": "法術位[Spell Slots]",
 								"entries": [
-									"The Bard table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
-									"For example, if you know the 1st-level spell {@spell cure wounds} and have a 1st-level and a 2nd-level spell slot available, you can cast {@spell cure wounds} using either slot."
+									"吟遊詩人表顯示了你有多少法術位來施展你的一級以上法術。要施放其中一個法術，你必須使用該法術等級或更高的一個法術位。當你完成一個長休後，你會重新獲得所有法術位。",
+									"例如，如果你知道一級法術{@spell 治療傷勢[Cure Wounds]}，並且有一個一級和二級法術位可以使用，那麼您可以使用任意一個位來施放{@spell 治療傷勢[Cure Wounds]}。"
 								]
 							},
 							{
 								"type": "entries",
-								"name": "Spells Known of 1st Level and Higher",
+								"name": "一級及以上的法術[Spells Known of 1st Level and Higher]",
 								"entries": [
-									"You know four 1st-level spells of your choice from the bard spell list.",
-									"You learn an additional bard spell of your choice at each level except 12th, 16th, 19th, and 20th. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level.",
-									"Additionally, when you gain a level in this class, you can choose one of the bard spells you know and replace it with another spell from the bard spell list, which also must be of a level for which you have spell slots."
+									"１級時，你從詩人法術列表裏選擇４個法術作為自己的已知法術。",
+									"除了第12、第16、第19和第20級，你可以在每個等級學習額外的吟遊詩人法術。每一個法術都必須是你有法術位的級別。例如，當你3級時，你可以學習1級或2級的新法術。",
+									"額外的，當你在本職業獲得１個新職業等級時，你可以從吟遊詩人法術列表裏選擇１個新的法術來代替一個舊的詩人已知法術。新法術必須有可以被施展的法術位。"
 								]
 							},
 							{
 								"type": "entries",
-								"name": "Spellcasting Ability",
+								"name": "施法能力值[Spellcasting Ability]",
 								"entries": [
-									"Charisma is your spellcasting ability for your bard spells. Your magic comes from the heart and soul you pour into the performance of your music or oration. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a bard spell you cast and when making an attack roll with one.",
+									"你的吟遊詩人法術的魔法能力值是魅力。抵抗你的法術的難度(DC)等同 8 + 你的熟練加值 + 你的魅力調整值。你的法術的攻擊加值為你的熟練加值 + 你的魅力調整值。",
 									{
 										"type": "abilityDc",
 										"name": "Spell",
@@ -447,16 +447,16 @@
 							},
 							{
 								"type": "entries",
-								"name": "Ritual Casting",
+								"name": "儀式施法[Ritual Casting]",
 								"entries": [
-									"You can cast any bard spell you know as a ritual if that spell has the ritual tag."
+									"你可以用儀式來施吟遊詩人的儀式法術。"
 								]
 							},
 							{
 								"type": "entries",
-								"name": "Spellcasting Focus",
+								"name": "施法法器[Spellcasting Focus]",
 								"entries": [
-									"You can use a musical instrument (found in chapter 5) as a spellcasting focus for your bard spells."
+									"你可以使用你的樂器，來做為你施放吟遊詩人法術的法器。"
 								]
 							}
 						]
@@ -464,69 +464,69 @@
 				],
 				[
 					{
-						"name": "Jack of All Trades",
+						"name": "全能高手[Jack of All Trades]",
 						"entries": [
-							"Starting at 2nd level, you can add half your proficiency bonus, rounded down, to any ability check you make that doesn't already include your proficiency bonus."
+							"第二級後，你可將一半的熟練加值(下折)加在你未熟練的能力檢定之中。"
 						]
 					},
 					{
-						"name": "Song of Rest (d6)",
+						"name": "紓壓曲[Song of Rest] (d6)",
 						"entries": [
-							"Beginning at 2nd level, you can use soothing music or oration to help revitalize your wounded allies during a short rest. If you or any friendly creatures who can hear your performance regain hit points by spending Hit Dice at the end of the short rest, each of those creatures regains an extra 1d6 hit points.",
-							"The extra hit points increase when you reach certain levels in this class: to 1d8 at 9th level, to 1d10 at 13th level, and to 1d12 at 17th level."
+							"第二級後，你可以在短休時使用音樂或吟詩還幫助你的盟友治療。聽的到你的生物如果這時需要回血，那他可以格外的多1d6的回血骰。",
+							"紓壓曲骰會隨著等級調升： 9 等 1d8 、13 等 1d10 、17 等 1d12。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Bard College",
+						"name": "吟遊學院[Bard College]",
 						"entries": [
-							"At 3rd level, you delve into the advanced techniques of a bard college of your choice from the list of available colleges. Your choice grants you features at 3rd level and again at 6th and 14th level."
+							"三級時，你專精於你研究的詩人學院，你可以選擇學院。你的學院使你擁有特殊的技巧，在你 3、6、以及14級時給你額外的特性。"
 						],
 						"gainSubclassFeature": true
 					},
 					{
-						"name": "Expertise",
+						"name": "專精[Expertise]",
 						"entries": [
-							"At 3rd level, choose two of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses either of the chosen proficiencies.",
-							"At 10th level, you can choose another two skill proficiencies to gain this benefit."
+							"第三級後，你可以選擇兩種以熟練的技能，當你需要做技能檢定時，這兩個技能所屬的技能熟練加值會加一倍(X2)。",
+							"第十級後，你可以再選擇另外兩種以熟練的技能。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 4th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達４級，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Bardic Inspiration (d8)",
+						"name": "吟遊激勵[Bardic Inspiration] (d8)",
 						"entries": [
-							"At 5th level, your Bardic Inspiration die changes to a d8."
+							"５級時，你的吟遊激勵骰改為 d8。"
 						]
 					},
 					{
-						"name": "Font of Inspiration",
+						"name": "靈感回充[Font of Inspiration]",
 						"entries": [
-							"Beginning when you reach 5th level, you regain all of your expended uses of Bardic Inspiration when you finish a short or long rest."
+							"５級時，吟遊激勵骰在短休或長休後都能全部恢復。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Countercharm",
+						"name": "反制迷惑[Countercharm]",
 						"entries": [
-							"At 6th level, you gain the ability to use musical notes or words of power to disrupt mind-influencing effects. As an action, you can start a performance that lasts until the end of your next turn. During that time, you and any friendly creatures within 30 feet of you have advantage on saving throws against being {@condition frightened} or {@condition charmed}. A creature must be able to hear you to gain this benefit. The performance ends early if you are {@condition incapacitated} or silenced or if you voluntarily end it (no action required)."
+							"６級時，你可以使用你的音樂或詩詞來干擾他人的心靈引響。使用一個回合，你將開始表演至此回合結束。這段時間內你與30尺內的盟友都可在{@condition 恐慌[Frightened]}或{@condition 迷惑[Charmed]}赦免上得到優勢。生物必須要聽的到你。此加成會因{@condition 乏力[Incapacitated]}、安靜或自願解除(不須動作)而消失。"
 						]
 					},
 					{
-						"name": "Bard College feature",
+						"name": "吟遊學院特性[Bard College feature]",
 						"entries": [
-							"At 6th level, you gain a feature from your Bard College."
+							"６級時，你從你的學院得到新的特性。"
 						],
 						"gainSubclassFeature": true
 					}
@@ -534,125 +534,125 @@
 				[],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達８級，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Song of Rest (d8)",
+						"name": "紓壓曲[Song of Rest] (d8)",
 						"entries": [
-							"At 9th level, the extra hit points gained from Song of Rest increases to 1d8."
+							"９級時，紓壓取恢復的生命增加為 1d8 。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Bardic Inspiration (d10)",
+						"name": "吟遊激勵[Bardic Inspiration] (d10)",
 						"entries": [
-							"At 10th level, your Bardic Inspiration die changes to a d10."
+							"１０級時，你的吟遊激勵骰改為 d10。"
 						]
 					},
 					{
-						"name": "Expertise",
+						"name": "專精[Expertise]",
 						"entries": [
-							"At 10th level, you can choose another two skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses either of the chosen proficiencies."
+							"１０級時，你可以選擇兩種以熟練的技能，當你需要做技能檢定時，這兩個技能所屬的技能熟練加值會加一倍(X2)。"
 						]
 					},
 					{
-						"name": "Magical Secrets",
+						"name": "魔法秘密[Magical Secrets]",
 						"entries": [
-							"By 10th level, you have plundered magical knowledge from a wide spectrum of disciplines. Choose two spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip.",
-							"The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table.",
-							"You learn two additional spells from any class at 14th level and again at 18th level."
+							"１０級後，你對法術知識更加了解。你可以選擇其他職業任何兩種法術包括此級獲得的法術。法術一定要在你可施展的環數內，或是戲法。",
+							"所選擇的法術視為吟遊詩人的法術，也可將這法術寫在吟遊詩人法術欄上。",
+							"你分別在１４級跟１８級都可以額外多學兩種其他職業法術。"
 						]
 					}
 				],
 				[],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１２級，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Song of Rest (d10)",
+						"name": "紓壓曲[Song of Rest] (d10)",
 						"entries": [
-							"At 13th level, the extra hit points gained from Song of Rest increases to 1d10."
+							"１３級時，紓壓取恢復的生命增加為 1d10 。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Magical Secrets",
+						"name": "魔法秘密[Magical Secrets]",
 						"entries": [
-							"At 14th level, choose two additional spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip.",
-							"The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table."
+							"１４級後，你對法術知識更加了解。你可以選擇其他職業任何兩種法術包括此級獲得的法術。法術一定要在你可施展的環數內，或是戲法。",
+							"所選擇的法術視為吟遊詩人的法術，也可將這法術寫在吟遊詩人法術欄上。"
 						]
 					},
 					{
-						"name": "Bard College feature",
+						"name": "吟遊學院特性[Bard College feature]",
 						"entries": [
-							"At 14th level, you gain a feature from your Bard College."
+							"１４級時，你從你的學院得到新的特性。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Bardic Inspiration (d12)",
+						"name": "吟遊激勵[Bardic Inspiration] (d12)",
 						"entries": [
-							"At 15th level, your Bardic Inspiration die changes to a d12."
+							"１５級時，你的吟遊激勵骰改為 d12。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１６級，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Song of Rest (d12)",
+						"name": "紓壓曲[Song of Rest] (d12)",
 						"entries": [
-							"At 17th level, the extra hit points gained from Song of Rest increases to 1d12."
+							"１７級時，紓壓取恢復的生命增加為 1d12 。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Magical Secrets",
+						"name": "魔法秘密[Magical Secrets]",
 						"entries": [
-							"At 18th level, choose two additional spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip.",
-							"The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table."
+							"１８級後，你對法術知識更加了解。你可以選擇其他職業任何兩種法術包括此級獲得的法術。法術一定要在你可施展的環數內，或是戲法。",
+							"所選擇的法術視為吟遊詩人的法術，也可將這法術寫在吟遊詩人法術欄上。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１９級，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Superior Inspiration",
+						"name": "激勵專精[Superior Inspiration]",
 						"entries": [
-							"At 20th level, when you roll initiative and have no uses of Bardic Inspiration left, you regain one use."
+							"第20級後，當每次做先攻檢定時，如果你沒有吟遊激勵骰，那你會恢復一個吟遊激勵骰。"
 						]
 					}
 				]

--- a/data/class/class-rogue.json
+++ b/data/class/class-rogue.json
@@ -1,7 +1,7 @@
 {
 	"class": [
 		{
-			"name": "Rogue",
+			"name": "遊蕩者[Rogue]",
 			"source": "PHB",
 			"hd": {
 				"number": 1,
@@ -14,7 +14,7 @@
 			"classTableGroups": [
 				{
 					"colLabels": [
-						"Sneak Attack"
+						"偷襲[Sneak Attack]"
 					],
 					"rows": [
 						[
@@ -247,8 +247,8 @@
 						}
 					],
 					"colLabels": [
-						"{@filter Cantrips Known|spells|level=0|subclass=Arcane Trickster}",
-						"Spells Known"
+						"{@filter 已知戲法|spells|level=0|subclass=Arcane Trickster}",
+						"已知法術"
 					],
 					"rows": [
 						[
@@ -334,7 +334,7 @@
 					]
 				},
 				{
-					"title": "Spell Slots per Spell Level",
+					"title": "每等級法術位",
 					"subclasses": [
 						{
 							"name": "Arcane Trickster",
@@ -488,17 +488,17 @@
 				"skills": {
 					"choose": 4,
 					"from": [
-						"Acrobatics",
-						"Athletics",
-						"Deception",
-						"Insight",
-						"Intimidation",
-						"Investigation",
-						"Perception",
-						"Performance",
-						"Persuasion",
-						"Sleight of Hand",
-						"Stealth"
+						"特技動作[Acrobatics]",
+						"運動[Athletics]",
+						"欺暪[Deception]",
+						"察言觀色[Insight]",
+						"恐嚇[Intimidation]",
+						"調查[Investigation]",
+						"觀察[Perception]",
+						"表演[Performance]",
+						"說服[Persuasion]",
+						"巧手[Sleight of Hand]",
+						"隱藏[Stealth]"
 					]
 				}
 			},
@@ -515,188 +515,188 @@
 			"classFeatures": [
 				[
 					{
-						"name": "Expertise",
+						"name": "專業知識[Expertise]",
 						"entries": [
-							"At 1st level, choose two of your skill proficiencies, or one of your skill proficiencies and your proficiency with thieves' tools. Your proficiency bonus is doubled for any ability check you make that uses either of the chosen proficiencies.",
-							"At 6th level, you can choose two more of your proficiencies (in skills or with thieves' tools) to gain this benefit."
+							"１級起，選擇兩個你熟練的技能，或者一個你熟練的技能和盜賊工具[thieves' tools]熟練。你在用任意選擇的熟練做能力檢定時，加上雙倍的熟練加值。",
+							"６級時，你可以再選擇兩項你熟練的技能或者盜賊工具[thieves' tools]）受益於此特性。"
 						]
 					},
 					{
-						"name": "Sneak Attack",
+						"name": "偷襲[Sneak Attack]",
 						"entries": [
-							"Beginning at 1st level, you know how to strike subtly and exploit a foe's distraction. Once per turn, you can deal an extra 1d6 damage to one creature you hit with an attack if you have advantage on the attack roll. The attack must use a finesse or a ranged weapon.",
-							"You don't need advantage on the attack roll if another enemy of the target is within 5 feet of it, that enemy isn't {@condition incapacitated}, and you don't have disadvantage on the attack roll.",
-							"The amount of the extra damage increases as you gain levels in this class, as shown in the Sneak Attack column of the Rogue table."
+							"從１級起，你知道如何精確地攻擊分心的敵人。每回合一次，你可以在擊中一個生物且此攻擊骰帶有優勢的情況下，額外造成１ｄ６傷害。此攻擊必須使用靈巧或遠程武器。",
+							"如果目標５尺內有另一個敵人，且此敵人可以行動，你的攻擊骰也沒有劣勢，則你攻擊骰不需要優勢。",
+							"額外的偷襲傷害隨你的游蕩者等級增加，具體如遊蕩者列表所示。"
 						]
 					},
 					{
-						"name": "Thieves' Cant",
+						"name": "賊話[Thieves' Cant]",
 						"entries": [
-							"During your rogue training you learned thieves' cant, a secret mix of dialect, jargon, and code that allows you to hide messages in seemingly normal conversation. Only another creature that knows thieves' cant understands such messages. It takes four times longer to convey such a message than it does to speak the same idea plainly.",
-							"In addition, you understand a set of secret signs and symbols used to convey short, simple messages, such as whether an area is dangerous or the territory of a thieves' guild, whether loot is nearby, or whether the people in an area are easy marks or will provide a safe house for thieves on the run."
+							"基於你的游蕩者訓練，你學會了賊話，一種混合了土話，術語和代碼的秘密語言讓你能夠將信息隱藏在看起來很平常的對話中。只有另外一個懂賊話的生物能看懂此信息。用此法傳達信息需要花費４倍於直接說出的文字和話語。",
+							"此外，你懂得一套秘密符文和標識用以傳達簡單短小的信息，例如一個地區是否危險，是否受盜賊公會管轄，附近是否有戰利品，附近的人是否好主顧或者路上是否有安全的房屋以供庇護。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Cunning Action",
+						"name": "巧妙動作[Cunning Action]",
 						"entries": [
-							"Starting at 2nd level, your quick thinking and agility allow you to move and act quickly. You can take a bonus action on each of your turns in combat. This action can be used only to take the Dash, Disengage, or Hide action."
+							"２級起，你的急才和靈巧允許你快速移動或作出動作。在戰鬥中你每回合可以使用你的附贈動作來執行撤離（disengage），疾行（dash）或躲藏（hide）。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Roguish Archetype",
+						"name": "遊蕩者範型[Roguish Archetype]",
 						"entries": [
-							"At 3rd level, you choose an archetype that you emulate in the exercise of your rogue abilities from the list of available archetypes. Your archetype choice grants you features at 3rd level and then again at 9th, 13th, and 17th level."
+							"３級起，你選擇一項範型用以提升你的遊蕩者能力：盜賊，刺客或者詭術師，所有的細節都在職業描述之後。你選擇的范型會在３級，９級，１３級和１７級給予你特性。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 4th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達４級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Uncanny Dodge",
+						"name": "直覺閃避[Uncanny Dodge]",
 						"entries": [
-							"Starting at 5th level, when an attacker that you can see hits you with an attack, you can use your reaction to halve the attack's damage against you."
+							"５級起，當一個能見的敵人用攻擊命中了你，你可以用反應讓此次攻擊的傷害減半。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Expertise",
+						"name": "專業知識[Expertise]",
 						"entries": [
-							"At 6th level, you can choose two more of your proficiencies (in skills or with thieves' tools) to gain the benefit of Expertise."
+							"６級時，你可以再選擇兩項你熟練的技能或者盜賊工具[thieves' tools]）受益於此特性。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Evasion",
+						"name": "反射閃避[Evasion]",
 						"entries": [
-							"Beginning at 7th level, you can nimbly dodge out of the way of certain area effects, such as a red dragon's fiery breath or an {@spell ice storm} spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail."
+							"７級起，你可以靈活地閃出某些范圍效果，例如紅龍的噴吐攻擊或者冰風暴法術。當你受到一個讓你做敏捷豁免，通過則傷害減半的效果時，通過豁免則不受傷，沒通過也只受到一半的傷害。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達８級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Roguish Archetype feature",
+						"name": "遊蕩者範型[Roguish Archetype]",
 						"entries": [
-							"At 9th level, you gain a feature granted by your Roguish Archetype."
+							"９級時你獲得範型給予你的新特性。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 10th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１０級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Reliable Talent",
+						"name": "可靠才能[Reliable Talent]",
 						"entries": [
-							"By 11th level, you have refined your chosen skills until they approach perfection. Whenever you make an ability check that lets you add your proficiency bonus, you can treat a d20 roll of 9 or lower as a 10."
+							"１１級起，你對你選擇的技能使用得更加完美。每當你使用讓你加上熟練加值的能力檢定時，你可以將ｄ２０骰中９或以下的結果都視為１０。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１２級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Roguish Archetype feature",
+						"name": "遊蕩者範型[Roguish Archetype]",
 						"entries": [
-							"At 13th level, you gain a feature granted by your Roguish Archetype."
+							"１３級時你獲得範型給予你的新特性。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Blindsense",
+						"name": "盲感[Blindsense]",
 						"entries": [
-							"Starting at 14th level, if you are able to hear, you are aware of the location of any hidden or {@condition invisible} creature within 10 feet of you."
+							"１４級起，只要你還能聽見聲音，你可以定位出在你１０尺內躲藏或{@condition 隱形[Invisible]}的生物。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Slippery Mind",
+						"name": "心智靈活[Slippery Mind]",
 						"entries": [
-							"By 15th level, you have acquired greater mental strength. You gain proficiency in Wisdom saving throws."
+							"１５級起，你獲得強大的心靈力量。你的感知豁免獲得熟練。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１６級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Roguish Archetype feature",
+						"name": "遊蕩者範型[Roguish Archetype]",
 						"entries": [
-							"At 17th level, you gain a feature granted by your Roguish Archetype."
+							"１７級時你獲得範型給予你的新特性。"
 						],
 						"gainSubclassFeature": true
 					}
 				],
 				[
 					{
-						"name": "Elusive",
+						"name": "難以捉摸[Elusive]",
 						"entries": [
-							"Beginning at 18th level, you are so evasive that attackers rarely gain the upper hand against you. No attack roll has advantage against you while you aren't {@condition incapacitated}."
+							"１８級起，你如此難以捉摸以至於攻擊你的攻擊者無法獲得優勢。除非你{@condition 乏力[Incapacitated]}，否則攻擊你的攻擊骰不能獲得優勢。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Ability Score Improvement",
+						"name": "能力值提升[Ability Score Improvement]",
 						"entries": [
-							"When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature.",
-							"If your DM allows the use of feats, you may instead take a feat."
+							"當你到達１９級時，你可以讓你選擇的一個能力值提升２點或者選擇的兩項能力值提升１點。通常情況下，你不能將你的屬性值用此特性提升到２０以上。",
+							"如果你的 DM 允許習得專長，你可以改為獲得一個專長。"
 						]
 					}
 				],
 				[
 					{
-						"name": "Stroke of Luck",
+						"name": "幸運一擊[Stroke of Luck]",
 						"entries": [
-							"At 20th level, you have an uncanny knack for succeeding when you need to. If your attack misses a target within range, you can turn the miss into a hit. Alternatively, if you fail an ability check, you can treat the d20 roll as a 20.",
-							"Once you use this feature, you can't use it again until you finish a short or long rest."
+							"２０級起，你獲得神奇的才能讓你在需要成功時獲得成功。如果你對目標進行的攻擊丟失，你可以將此次丟失改為命中。同樣的，如果你在一次能力檢定中失敗了，你可以將ｄ２０骰的結果視作投出了２０。",
+							"一旦你使用了此特性，你就不能再次使用，直到你進行一次短休息或者長休息。"
 						]
 					}
 				]
@@ -708,39 +708,39 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Arcane Trickster",
+								"name": "詭術師[Arcane Trickster]",
 								"entries": [
-									"Some rogues enhance their fine-honed skills of stealth and agility with magic, learning tricks of enchantment and illusion. These rogues include pickpockets and burglars, but also pranksters, mischief-makers, and a significant number of adventurers.",
+									"一些游蕩者使用魔法來提高他們隱匿和靈巧的能力，從而學習了附魔和幻術的詭術。這些游蕩者包括扒手和竊賊，不過也包括惡作劇者，和一部分冒險者。",
 									{
 										"type": "entries",
-										"name": "Mage Hand Legerdemain",
+										"name": "法師之手詐術[Mage Hand Legerdemain]",
 										"entries": [
-											"Starting at 3rd level, when you cast {@spell mage hand}, you can make the spectral hand {@condition invisible}, and you can perform the following additional tasks with it:",
+											"３級起，當你施展{@spell 法師之手[mage hand]}，你可以制作一個{@condition 隱形[Invisible]}的幽靈手，並且你可以用它來做以下特殊的任務：",
 											{
 												"type": "list",
 												"items": [
-													"You can stow one object the hand is holding in a container worn or carried by another creature.",
-													"You can retrieve an object in a container worn or carried by another creature.",
-													"You can use thieves' tools to pick lock and disarm traps at range."
+													"你可以傳遞一個物體到其他生物攜帶或穿著的容器中。",
+													"你可以取回一個被其他生物攜帶或穿著的容器裡的物體。",
+													"你可以用盜賊工具在范圍內開鎖和解除陷阱。"
 												]
 											},
-											"You can perform one of these tasks without being noticed by a creature if you succeed on a Dexterity (Sleight of Hand) check contested by the creature's Wisdom (Perception) check.",
-											"In addition, you can use the bonus action granted by your Cunning Action to control the hand."
+											"你可以在不被對方發現下完成這些任務之一，前提是你成功的通過一個敏捷（巧手）檢定對抗該生物的感知（觀察）檢定。",
+											"另外，你可以用你巧妙動作[Cunning Action]獲得的附加動作來控制法師之手。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Spellcasting",
+										"name": "施法",
 										"entries": [
-											"When you reach 3rd level, you gain the ability to cast spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the wizard spell list.",
+											"３級起，你獲得施法能力。參見１０章的施法通用規則和１１章的法師法術列表。",
 											{
 												"type": "entries",
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Cantrips",
+														"name": "戲法[Cantrips]",
 														"entries": [
-															"You learn three cantrips: {@spell mage hand} and two other cantrips of your choice from the wizard spell list. You learn another wizard cantrip of your choice at 10th level."
+															"你學會３個戲法：{@spell 法師之手[mage hand]}和另外兩個你從法師法術列表中選擇的戲法。你在１０級時學習另外一個你選擇的法師戲法。"
 														]
 													}
 												]
@@ -750,10 +750,10 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Spell Slots",
+														"name": "法術位",
 														"entries": [
-															"The Arcane Trickster Spellcasting table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
-															"For example, if you know the 1st-level spell {@spell charm person} and have a 1st-level and a 2nd-level spell slot available, you can cast {@spell charm person} using either slot."
+															"詭術師施法列表展示了你可以施展多少個１級或更高級的法術。要施展相應法術，你必須支付一個跟法術等級相等或更高的法術位。你在一次長休息之後獲得所有使用過的法術位。",
+															"例如，如果你已知１級法術{@spell 迷惑人類[charm person]}並且有１級和２級的法術位，你可以用這兩種法術位中的任意一種來施展{@spell 迷惑人類[charm person]}。"
 														]
 													}
 												]
@@ -763,12 +763,12 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Spells Known of 1st-Level and Higher",
+														"name": "知曉１級或高級法術",
 														"entries": [
-															"You know three 1st-level wizard spells of your choice, two of which you must choose from the enchantment and illusion spells on the wizard spell list.",
-															"The Spells Known column of the Arcane Trickster Spellcasting table shows when you learn more wizard spells of 1st level or higher. Each of these spells must be an enchantment or illusion spell of your choice, and must be of a level for which you have spell slots. For instance, when you reach 7th level in this class, you can learn one new spell of 1st or 2nd level.",
-															"The spells you learn at 8th, 14th, and 20th level can come from any school of magic.",
-															"Whenever you gain a level in this class, you can replace one of the wizard spells you know with another spell of your choice from the wizard spell list. The new spell must be of a level for which you have spell slots, and it must be an enchantment or illusion spell, unless you're replacing the spell you gained at 8th, 14th, or 20th level."
+															"你知曉３個你選擇的１級法師法術，其中兩個你必須從法師列表的附魔[enchantment]和幻術[illusion]學派法術中選擇。",
+															"詭術師法術列表的已知法術列展示了你什麼時候可以學習更多的１級或高級法師法術。這些法術都必須是附魔和幻術學派，並且必須是你已有法術位等級的法術。例如，你在７級的時候可以獲得一個新的１級或２級法術。",
+															"你在８級，１４級和２０級的時候可以學習任意學派的法術。",
+															"當你在此職業上獲得了等級，你可以將你已知的一個法術替換成你在法師法術列表中選擇的另外一個法術。這個新的法術等級必須滿足你已有的法術位等級，除非你在８級，１４級或２０級替換，否則替換法術必須是附魔或幻術學派的法術。"
 														]
 													}
 												]
@@ -778,9 +778,9 @@
 												"entries": [
 													{
 														"type": "entries",
-														"name": "Spellcasting Ability",
+														"name": "施法能力",
 														"entries": [
-															"Intelligence is your spellcasting ability for your wizard spells, since you learn your spells through dedicated study and memorization. You use your Intelligence whenever a spell refers to your spellcasting ability. In addition, you use your Intelligence modifier when setting the saving throw DC for a wizard spell you cast and when making an attack roll with one.",
+															"智力是你施展法師法術的關鍵屬性，因為你通過研究和記憶來學習法術。每當法術指向你的施法關鍵屬性時，你使用智力屬性。另外，當決定你法師法術的豁免ＤＣ和攻擊檢定時，是用智力調整值。",
 															{
 																"type": "abilityDc",
 																"name": "Spell",
@@ -809,9 +809,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Magical Ambush",
+										"name": "詭術伏擊[Magical Ambush]",
 										"entries": [
-											"Starting at 9th level, if you are hidden from a creature when you cast a spell on it, the creature has disadvantage on any saving throw it makes against the spell this turn."
+											"９級起，如果你在躲藏的狀態對一個生物施法，則此生物在此回合對抗此法術的任意豁免骰上有劣勢。"
 										]
 									}
 								]
@@ -822,9 +822,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Versatile Trickster",
+										"name": "萬能詭術[Versatile Trickster]",
 										"entries": [
-											"At 13th level, you gain the ability to distract targets with your {@spell mage hand}. As a bonus action on your turn, you can designate a creature within 5 feet of the spectral hand created by the spell. Doing so gives you advantage on attack rolls against that creature until the end of the turn."
+											"１３級起，你得到用{@spell 法師之手[mage hand]}使目標分心的能力。在你的回合中，通過一個附加動作，你可以用法師之手指定一個５尺內的生物。若如此做，你在此輪結束前對該生物的攻擊帶有優勢。"
 										]
 									}
 								]
@@ -835,11 +835,11 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Spell Thief",
+										"name": "法術盜賊[Spell Thief]",
 										"entries": [
-											"At 17th level, you gain the ability to magically steal the knowledge of how to cast a spell from another spellcaster.",
-											"Immediately after a creature casts a spell that targets you or includes you in its area of effect, you can use your reaction to force the creature to make a saving throw with its spellcasting ability modifier. The DC equals your spell save DC. On a failed save, you negate the spell's effect against you, and you steal the knowledge of the spell if it is at least 1st level and of a level you can cast (it doesn't need to be a wizard spell). For the next 8 hours, you know the spell and can cast it using your spell slots. The creature can't cast that spell until the 8 hours have passed.",
-											"Once you use this feature, you can't use it again until you finish a long rest."
+											"１７級起，你獲得如何從其他施法者手中盜取施法能力的知識。",
+											"當一個生物施展以你為目標或施展一個包含你的區域效果的法術，你可以立即用你的反應強迫此生物使用它的施法能力調整值做一次豁免。此ＤＣ等同於你的法術豁免ＤＣ。如果他沒有通過豁免，且此法術至少為１級並且你有法術位可以施展（不需要是法師的法術），你取消此法術對你的效果，並且盜取該法術的知識。在接下來的８小時內，你知曉此法術並且能用你的法術位施放它。此生物不能再施放此法術直到８小時後。",
+											"一旦你使用了此特性，你就不能再次使用，直到你進行一次長休息。"
 										]
 									}
 								]
@@ -854,22 +854,22 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Assassin",
+								"name": "刺客[Assassin]",
 								"entries": [
-									"You focus your training on the grim art of the death. Those who adhere to this archetype are diverse - hired killers, spies, bounty hunters, and even specially anointed priests trained to exterminate the enemies of their deity. Stealth, poison, and disguise help you eliminate your foes with deadly efficiency.",
-									"Your archetype grants you features at 3rd level and then again at 9th, 13th, and 17th level.",
+									"你專注於殘忍冷酷的死亡藝術。那些選擇此范型的游蕩者多種多樣：雇傭殺手，間諜，賞金獵人，甚至那些為他們的神殲滅敵人的特殊祭司。隱匿，用毒和易容能幫助你有效地排除你的敵人。",
+									"你選擇的範型會在３級，９級，１３級和１７級給予你特性。",
 									{
 										"type": "entries",
-										"name": "Assassinate",
+										"name": "暗殺[Assassinate]",
 										"entries": [
-											"Starting at 3rd level, you are at your deadliest when you get the drop on your enemies. You have advantage on attack rolls against any creature that hasn't taken a turn in the combat yet. In addition, any hit you score against a creature that is surprised is a critical hit."
+											"３級起，當你先發制人時是最致命的。你對戰鬥中還沒有輪過回合的生物在攻擊骰上獲得優勢。另外，你攻擊命中被突襲的生物，則造成重擊。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Bonus Proficiencies",
+										"name": "獎勵熟練[Bonus Proficiencies]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you gain proficiency with the disguise kit and the poisoner's kit."
+											"你選擇此範型的３級起，你在易容工具[disguise kit]和制毒者工具[poisoner's kit]上獲得熟練。"
 										]
 									}
 								]
@@ -880,10 +880,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Infiltration Expertise",
+										"name": "專業滲透[Infiltration Expertise]",
 										"entries": [
-											"Starting at 9th level, you can unfailingly create false identities for yourself. You must spend seven days and 25 gp to establish the history, profession, and affiliations for an identity. You can't establish an identity that belongs to someone else. For example, you might acquire appropriate clothing, letters of introduction, and official-looking certification to establish yourself as a member of a trading house from a remote city so you can insinuate yourself into the company of other wealthy merchants.",
-											"Thereafter, if you adopt the new identity as a disguise, other creatures believe you to be that person until given an obvious reason not to."
+											"９級起，你可以不停地為你自己偽造身份。你必須花費７天和２５金幣來為身份編造歷史，專業和人際關系。你不能為他人偽造身份。例如，你獲得相應的衣服，介紹信和官方證明，使得你自己看上去是一個來自偏遠城市貿易屋的成員，然後你就可以混入其他商人中間。",
+											"之後，如果你通過易容獲取了這個身份，其他生物就相信你是那個人直到你給出一個明顯的原因證明你不是。"
 										]
 									}
 								]
@@ -894,10 +894,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Impostor",
+										"name": "冒充者[Impostor]",
 										"entries": [
-											"At 13th level, you gain the ability to unerringly mimic another person's speech, writing, and behavior. You must spend at least three hours studying these three components of the person's behavior, listening to speech, examining handwriting, and observing mannerism.",
-											"Your ruse is indiscernible to the casual observer. If a wary creature suspects something is amiss, you have advantage on any Charisma (Deception) check you make to avoid detection."
+											"１３級起，你獲得准確模仿他人說話，寫字和行為的能力。你必須花費至少３小時來學習人們的這３中行為成分，聽他們說話，練習寫字並且觀察特殊習慣。",
+											"你的詭計是讓人難以分辨的，如果一個謹慎的生物察覺到了一些缺陷，你在任意魅力（欺詐）檢定中有優勢來避免察覺。"
 										]
 									}
 								]
@@ -908,9 +908,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Death Strike",
+										"name": "死亡打擊[Death Strike]",
 										"entries": [
-											"Starting at 17th level, you become a master of instant death. When you attack and hit a creature that is surprised, it must make a Constitution saving throw (DC 8 + your Dexterity modifier + your proficiency bonus). On a failed save, double the damage of your attack against the creature."
+											"１７級起，你成為了瞬間致命的大師。當你攻擊命中一個被突襲的生物，該生物必須做一個體魄豁免（ＤＣ８＋你的敏捷調整值＋你的熟練加值）。如果未通過，你可以對其造成雙倍傷害。"
 										]
 									}
 								]
@@ -925,22 +925,22 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Mastermind",
+								"name": "策士[Mastermind]",
 								"entries": [
-									"Your focus is on people and on the influence and secrets they have. Many spies, courtiers, and schemers follow this archetype, leading lives of intrigue. Words are your weapons as often as knives or poison, and secrets and favors are some of your favorite treasures.",
+									"策士專註於對人們施加影響和知曉他們的秘密。許多間諜，朝臣和陰謀家會追隨這個範型，在密謀中渡過他們全部的生命。言語像你的匕首和毒藥一般作為你的武器，通過它們你得到你最喜歡的寶藏——人們的要害所在以及他們言不由衷的支持。",
 									{
 										"type": "entries",
-										"name": "Master of Intrigue",
+										"name": "陰謀大師[Master of Intrigue]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you gain proficiency with the disguise kit, the forgery kit, and one gaming set of your choice. You also learn two languages of your choice.",
-											"Additionally, you can unerringly mimic the speech patterns and accent of a creature that you hear speak for at least 1 minute, allowing you to pass yourself off as a native speaker of a particular land, provided that you know the language."
+											"從３級起，你可以得到易容工具[disguise kit]、文書偽造工具[forgery kit]和一種自選遊戲組[gaming set]的熟練。你同時可以學會兩種自選語言。",
+											"此外，如果你聽到一個生物講話長於1分鐘，你可以確切無誤地模仿他的語氣和口音。這允許你模仿來自某個特殊地區的特別口音，只要你知曉這種語言。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Master of Tactics",
+										"name": "戰術大師[Master of Tactics]",
 										"entries": [
-											"Starting at 3rd level, you can use the Help action as a bonus action. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the target can see or hear you."
+											"從第３級開始，你可以把協助動作作為附贈動作使用。此外，當你使用協助動作幫助一個盟友攻擊一個生物時，如果目標可以看到你或者聽到你的話，攻擊的目標可以在３０尺以內，而不是你的５尺之內。"
 										]
 									}
 								]
@@ -951,19 +951,19 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Insightful Manipulator",
+										"name": "洞察力[Insightful Manipulator]",
 										"entries": [
-											"Starting at 9th level, if you spend at least 1 minute observing or interacting with another creature outside combat, you can learn certain information about its capabilities compared to your own. The DM tells you if the creature is your equal, superior, or inferior in regard to two of the following characteristics of your choice:",
+											"從第９級開始，如果你至少花１分鐘觀察或與戰鬥之外的其他生物進行互動，你可以了解到跟你自己的能力相比較的某些訊息。在你選擇的下列兩個特徵中，DM告訴你是否與你的相等、優越或低等：",
 											{
 												"type": "list",
 												"items": [
-													"Intelligence score",
-													"Wisdom score",
-													"Charisma score",
-													"Class levels (if any)"
+													"智力值",
+													"感知值",
+													"魅力值",
+													"職業等級（如果有的話）"
 												]
 											},
-											"At the DM's option, you might also realize you know a piece of the creature's history or one of its personality traits, if it has any."
+											"如果你的DM允許，你也有可能知道這個生物的一段經歷或者它的一個性格特徵，如果它有的話。"
 										]
 									}
 								]
@@ -974,9 +974,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Misdirection",
+										"name": "誤導[Misdirection]",
 										"entries": [
-											"Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while a creature within 5 feet of you is granting you cover against that attack, you can use your reaction to have the attack target that creature instead of you."
+											"從13級起，你的急才有時候能讓另一個生物代替你承受攻擊。每當你成為一次攻擊的目標，並且在你的5尺距離內有生物為你對抗這次攻擊提供了掩蔽，你可以使用你的反應將這次攻擊的目標轉移給這個生物。"
 										]
 									}
 								]
@@ -987,10 +987,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Soul of Deceit",
+										"name": "心靈欺騙[Soul of Deceit]",
 										"entries": [
-											"Starting at 17th level, your thoughts can't be read by telepathy or other means, unless you allow it. You can present false thoughts by making a Charisma (Deception) check contested by the mind reader's Wisdom (Insight) check.",
-											"Additionally, no matter what you say, magic that would determine if you are telling the truth indicates you are being truthful, if you so choose, and you can't be compelled to tell the truth by magic."
+											"從17級起，除非你允許，否則你的思想不能被心靈感應或者其他能力閱讀。如果你使用魅力（欺瞞）檢定並在與思想閱讀者的感知（洞悉）檢定的對抗之中勝出，你還可以偽造思想使對方信以為真。",
+											"此外，不管你說什麽，你總是可以選擇讓魔法判定你在說真話並顯現出相應的跡象。你也不會因為魔法效應的影響而被強迫說出真話。"
 										]
 									}
 								]
@@ -1001,174 +1001,26 @@
 					"shortName": "Mastermind"
 				},
 				{
-					"name": "Inquisitive (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Inquisitive",
-								"entries": [
-									"As an archetypal Inquisitive, you excel at rooting out secrets and unraveling mysteries. You rely on your sharp eye for details, but also on your finely honed ability to read the words and deeds of other creatures to determine their true intent. You excel at defeating creatures that hide among and prey upon ordinary folk, and your mastery of lore and your sharp eye make you well equipped to expose and end hidden evils.",
-									{
-										"type": "entries",
-										"name": "Ear for Deceit",
-										"entries": [
-											"When you choose this archetype at 3rd level, you develop a keen ear for picking out lies. Whenever you make a Wisdom (Insight) check to sense if a creature is lying, you use the total of your check or 8 + your Wisdom modifier, whichever is higher. If you are proficient in Insight, you add your proficiency bonus to the fixed result. If you chose Insight as a skill augmented by your Expertise feature, add double your proficiency bonus."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Eye for Detail",
-										"entries": [
-											"Starting at 3rd level, you can use the bonus action granted by your Cunning Action feature to make a Wisdom (Perception) check to spot a hidden creature or object, to make an Intelligence (Investigation) check to uncover and decipher clues, or to use Insightful Fighting."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Insightful Fighting",
-										"entries": [
-											"At 3rd level, you gain the ability to decipher an opponent's tactics and develop a counter to them. As an action (or as a bonus action using Eye for Detail), you make a Wisdom (Insight) check against a creature you can see that isn't {@condition incapacitated}, opposed by the target's Charisma (Deception) check. If you succeed, you can use Sneak Attack against that creature even if you do not have advantage against it or if no enemy of the target is within 5 feet of it. You can use Sneak Attack in this way even if you have disadvantage against the target.",
-											"This benefit lasts for 1 minute or until you successfully use Insightful Fighting against a different target."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Steady Eye",
-										"entries": [
-											"At 9th level, you gain advantage on any Wisdom (Perception) check made on your turn to find a hidden creature or object if you do not move during that turn. If you use this ability before moving, you cannot move or ready movement during your turn."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Unerring Eye",
-										"entries": [
-											"At 13th level, you gain the ability to detect magical deception. As an action, you sense the presence within 30 feet of you of illusions, shapechanger creatures not in their true form, and other magic designed to deceive the senses. Though you determine that an effect is attempting to trick you, you gain no special insight into what is hidden or its true nature."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Eye for Weakness",
-										"entries": [
-											"At 17th level, you learn to exploit a creature's weaknesses by carefully studying its tactics and movement. While your Insightful Fighting feature applies to a creature, your Sneak Attack damage against that creature increases by 2d6."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UAGothicHeroes",
-					"shortName": "Inquisitive (UA)"
-				},
-				{
-					"name": "Swashbuckler",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Swashbuckler",
-								"entries": [
-									"You focus your training on the art of the blade, relying on speed, elegance, and charisma in equal parts. While other warriors are brutes clad in heavy armor, your method of fighting looks more like performance. Rakes, duelists, and pirates typically follow this archetype.",
-									"A swashbuckler excels in single combat, and can fight with two weapons while safely darting away from an opponent. Swashbucklers are especially talented at making difficult maneuvers to escape enemies or attack from an unexpected direction.",
-									{
-										"type": "entries",
-										"name": "Fancy Footwork",
-										"entries": [
-											"When you choose this archetype at 3rd level, you learn how to land a strike and then slip away without reprisal. During your turn, if you make a melee attack against a creature, that creature cannot make opportunity attacks against you for the rest of your turn."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Rakish Audacity",
-										"entries": [
-											"Starting at 3rd level, your unmistakable confidence propels you into battle. You add your Charisma modifier to your initiative rolls.",
-											"In addition, you don't need advantage on your attack roll to use your Sneak Attack if no creature other than your target is within 5 feet of you. All the other rules for the Sneak Attack class feature still apply to you."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Panache",
-										"entries": [
-											"At 9th level, your charm becomes extraordinarily beguiling. As an action, you can make a Charisma (Persuasion) check contested by a creature's Wisdom (Insight) check. The creature must be able to hear you, and the two of you must share a language.",
-											"If you succeed on the check and the creature is hostile to you, it has disadvantage on attack rolls against targets other than you and can't make opportunity attacks against targets other than you. This effect lasts for 1 minute, until one of your companions attacks the target or affects it with a spell, or until you and the target are more than 60 feet apart.",
-											"If you succeed on the check and the creature isn't hostile to you, it is {@condition charmed} by you for 1 minute. While {@condition charmed}, it regards you as a friendly acquaintance. This effect ends immediately if you or your companions do anything harmful to it."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Elegant Maneuver",
-										"entries": [
-											"Starting at 13th level, you can use a bonus action on your turn to gain advantage on the next Dexterity (Acrobatics) or Strength (Athletics) check you make during the same turn."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Master Duelist",
-										"entries": [
-											"Beginning at 17th level, your mastery of the blade lets you turn failure to success in combat. If you miss with an attack roll, you can choose to roll it again with advantage. Once you do so, you can't use this feature again until you finish a short or long rest."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "SCAG",
-					"shortName": "Swashbuckler"
-				},
-				{
 					"name": "Thief",
 					"subclassFeatures": [
 						[
 							{
-								"name": "Thief",
+								"name": "盜賊[Thief]",
 								"entries": [
-									"You hone your skills in the larcenous arts. Burglars, bandits, cutpurses, and other criminals typically follow this archetype, but so do rogues who prefer to think of themselves as professional treasure seekers, explorers, delvers, and investigators. In addition to improving your agility and stealth, you learn skills useful for delving into ancient ruins, reading unfamiliar languages, and using magic items you normally couldn't employ.",
+									"你磨練你的盜竊技能。竊賊，強盜，扒手和其他的犯罪類型常常追隨此范型，那些自視為尋寶者，探險家，探索者和調查員的游蕩者也是如此。除了提升你的靈巧和隱匿技術以外，你學會了如何探索古代廢墟，解讀非常見語言和使用魔法物品的技術。",
 									{
 										"type": "entries",
-										"name": "Fast Hands",
+										"name": "快手[Fast Hands]",
 										"entries": [
-											"Starting at 3rd level, you can use the bonus action granted by your Cunning Action to make a Dexterity (Sleight of Hand) check, use your thieves' tools to disarm a trap or open a lock, or take the Use an Object action."
+											"３級起，你可以使用從巧妙動作（Cunning Action）獲得的附贈動作做一個敏捷（巧手）檢定，使用你的盜賊工具來解除一個陷阱或者開鎖或者使用物件（Use an Object）動作。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Second-Story Work",
+										"name": "梁上君子[Second-Story Work]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you gain the ability to climb faster than normal; climbing no longer costs you extra movement.",
-											"In addition, when you make a running jump, the distance you cover increases by a number of feet equal to your Dexterity modifier."
+											"當你3級選擇此范型，你獲得比通常情況更快的攀爬速度；攀爬不再消耗你的額外移動。",
+											"此外，當你做一個有助跑的跳遠時，跳遠距離增加等於你敏捷調整值的尺數。"
 										]
 									}
 								]
@@ -1179,9 +1031,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Supreme Sneak",
+										"name": "卓越潛行[Supreme Sneak]",
 										"entries": [
-											"Starting at 9th level, you have advantage on a Dexterity (Stealth) check if you move no more than half your speed on the same turn."
+											"９級起，如果你在同一輪內移動不超過你速度的一半，你在敏捷（隱匿）檢定上有優勢。"
 										]
 									}
 								]
@@ -1192,9 +1044,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Use Magic Device",
+										"name": "使用魔法裝置[Use Magic Device]",
 										"entries": [
-											"By 13th level, you have learned enough about the workings of magic that you can improvise the use of items even when they are not intended for you. You ignore all class, race, and level requirements on the use of magic items."
+											"１３級起，你學會了足夠的魔法知識讓你使用並不是為你准備的魔法物品。你在使用魔法物品時，忽略所有職業，種族和等級的先決條件。"
 										]
 									}
 								]
@@ -1205,9 +1057,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Thief's Reflexes",
+										"name": "盜賊反射[Thief's Reflexes]",
 										"entries": [
-											"When you reach 17th level, you have become adept at laying ambushes and quickly escaping danger. You can take two turns during the first round of any combat. You take your first turn at your normal initiative and your second turn at your initiative minus 10. You can't use this feature when you are surprised."
+											"１７級起，你擅長伏擊和脫離危險。你在每場戰鬥的第一輪可以行動兩回合。你在你正常的先攻序列中執行第一回合，並在先攻－１０處執行你的第二回合。你不能在被突襲的情況下使用此特性。"
 										]
 									}
 								]
@@ -1218,102 +1070,33 @@
 					"shortName": "Thief"
 				},
 				{
-					"name": "Scout (UA)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Scout",
-								"entries": [
-									"You are skilled in woodcraft and stealth, allowing you to range ahead of your companions during expeditions. Rogues who embrace this archetype are at home in the wilderness and among barbarians and fighters, as they serve as the eyes and ears of war bands across the world. Compared to other rogues, you are skilled at surviving in the wilds.",
-									{
-										"type": "entries",
-										"name": "Survivalist",
-										"entries": [
-											"When you choose this archetype at 3rd level, you gain proficiency in the Nature and Survival skills. Your proficiency bonus is doubled for any ability check you make that uses either of those proficiencies."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Skirmisher",
-										"entries": [
-											"Starting at 3rd level, you are difficult to pin down during a fight. You can move up to half your speed as a reaction when an enemy ends its turn within 5 feet of you. This movement doesn't provoke opportunity attacks."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Superior Mobility",
-										"entries": [
-											"At 9th level, your walking speed increases by 10 feet. If you have a climbing or swimming speed, this increase applies to that speed as well."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Ambush Master",
-										"entries": [
-											"Starting at 13th level, you excel at leading ambushes. If any of your foes are surprised, you can use a bonus action on your turn in the first round of the combat to grant each ally who can see you a +5 bonus to initiative that lasts until the combat ends. If the initiative bonus would increase an ally's initiative above yours, the ally's initiative instead equals your initiative.",
-											"Each of the allies also receives a 10-foot increase to speed that lasts until the end of the ally's next turn."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Sudden Strike",
-										"entries": [
-											"Starting at 17th level, you can strike with deadly speed. If you take the Attack action on your turn, you can make one additional attack as a bonus action. This attack can benefit from your Sneak Attack even if you have already used it this turn, but only if the attack is the only one you make against the target this turn."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "UARangerAndRogue",
-					"shortName": "Scout (UA)"
-				},
-				{
 					"name": "Inquisitive",
 					"subclassFeatures": [
 						[
 							{
-								"name": "Inquisitive",
+								"name": "審判官[Inquisitive]",
 								"entries": [
-									"As an archetypal Inquisitive, you excel at rooting out secrets and unraveling mysteries. You rely on your sharp eye for detail, but also on your finely honed ability to read the words and deeds of other creatures to determine their true intent. You excel at defeating creatures that hide among and prey upon ordinary folk, and your mastery of lore and your keen deductions make you well equipped to expose and end hidden evils.",
+									"作為一名典型的審判官，你精於揭開秘密，開解謎團。你不光用銳利的雙眼去尋找細節，也使用磨練過的高超技藝去研讀其他生物的言辭和表情，以發現他們真實的意圖。你嫻於找出並擊敗那些藏身於平民，也以平民為食的怪物，而你的對於知識的掌握和銳利的眼目也讓你更好地揭示並終結潛藏的邪惡。",
 									{
 										"type": "entries",
-										"name": "Ear for Deceit",
+										"name": "聽聲辨謊[Ear for Deceit]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you develop a talent for picking out lies. Whenever you make a Wisdom (Insight) check to determine whether a creature is lying, treat a roll of 7 or lower on the d20 as an 8."
+											"當你在3級選擇此範型時，你的雙耳變得銳利，能發現謊言。當你進行一次感知（洞察）檢定來察覺一個生物是否在說謊時，你可以將d20投中7或更低的結果都視為8。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Eye for Detail",
+										"name": "細致入微[Eye for Detail]",
 										"entries": [
-											"Starting at 3rd level, you can use a bonus action to make a Wisdom (Perception) check to spot a hidden creature or object or to make an Intelligence (Investigation) check to uncover or decipher clues."
+											"3級起，你可以使用附贈動作來進行一次感知（觀察）檢定來偵測到一個隱藏的生物或物體，或者是進行一次智力（調查）檢定來揭示和破譯線索。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Insightful Fighting",
+										"name": "​戰鬥洞察[Insightful Fighting]",
 										"entries": [
-											"At 3rd level, you gain the ability to decipher an opponent's tactics and develop a counter to them. As a bonus action, you can make a Wisdom (Insight) check against a creature you can see that isn't {@condition incapacitated}, contested by the target's Charisma (Deception) check. If you succeed, you can use your Sneak Attack against that target even if you don't have advantage on the attack roll, but not if you have disadvantage on it.",
-											"This benefit lasts for 1 minute or until you successfully use this feature against a different target."
+											"3級時，你得到了解到一個敵人的戰術並加以反制的能力。以一個附贈動作，你對於一個你能看見的，並非失能的生物進行一次感知（洞察）檢定，對抗目標的魅力（欺瞞）檢定。若你成功，你可以在你並未對該生物具有優勢時對他發動偷襲攻擊，但在你的攻擊骰有劣勢時不行。",
+											"這個效果持續1分鐘或直到你成功的對另一個目標使用了戰鬥洞察為止。"
 										]
 									}
 								]
@@ -1324,9 +1107,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Steady Eye",
+										"name": "鎮定之眼[Steady Eye]",
 										"entries": [
-											"Starting at 9th level, you have advantage on any Wisdom (Perception) or Intelligence (Investigation) check if you move no more than half your speed on the same turn."
+											"9級時，你可以在進行任何感知（觀察）檢定或智力（調查）檢定中得到優勢，只要你在同一回合中移動不超過一半的速度。"
 										]
 									}
 								]
@@ -1337,10 +1120,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Unerring Eye",
+										"name": "精準之眼[Unerring Eye]",
 										"entries": [
-											"Beginning at 13th level, your senses are almost impossible to foil. As an action, you sense the presence of illusions, shapechangers not in their original form, and other magic designed to deceive the senses within 30 feet of you, provided you aren't {@condition blinded} or {@condition deafened}. You sense that an effect is attempting to trick you, but you gain no insight into what is hidden or into its true nature.",
-											"You can use this feature a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses of it when you finish a long rest."
+											"13級時，你得到偵測魔法欺瞞的能力。以一個動作，你感知到你周圍30英尺內的幻術存在，不在天生形態下的變形生物，和其他意在欺瞞感官的魔法，前提是你沒有目盲或耳聾。你能了解到了有一個效果正在試圖欺騙你，不過你並沒有得到對其後所掩蓋的真相和對他真實本質的特殊洞察力。",
+											"你可以使用這個功能的次數等於你的感知調整值（至少一次），當你完成一次長休，你重新獲得所有次數。"
 										]
 									}
 								]
@@ -1351,9 +1134,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Eye for Weakness",
+										"name": "識破弱點[Eye for Weakness]",
 										"entries": [
-											"At 17th level, you learn to exploit a creature's weaknesses by carefully studying its tactics and movement. While your Insightful Fighting feature applies to a creature, your Sneak Attack damage against that creature increases by 3d6."
+											"17級時，你學會通過認真的研究一個生物的戰術和移動來找到他的弱點的能力。當你的戰鬥洞察對一個生物使用時，你對該生物的偷襲傷害增加3d6。"
 										]
 									}
 								]
@@ -1364,105 +1147,25 @@
 					"shortName": "Inquisitive"
 				},
 				{
-					"name": "Mastermind",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Mastermind",
-								"entries": [
-									"Your focus is on people and on the influence and secrets they have. Many spies, courtiers, and schemers follow this archetype, leading lives of intrigue. Words are your weapons as often as knives or poison, and secrets and favors are some of your favorite treasures.",
-									{
-										"type": "entries",
-										"name": "Master of Intrigue",
-										"entries": [
-											"When you choose this archetype at 3rd level, you gain proficiency with the disguise kit, the forgery kit, and one gaming set of your choice. You also learn two languages of your choice.",
-											"Additionally, you can unerringly mimic the speech patterns and accent of a creature that you hear speak for at least 1 minute, enabling you to pass yourself off as a native speaker of a particular land, provided that you know the language."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Master of Tactics",
-										"entries": [
-											"Starting at 3rd level, you can use the Help action as a bonus action. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than within 5 feet of you, if the target can see or hear you."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Insightful Manipulator",
-										"entries": [
-											"Starting at 9th level, if you spend at least 1 minute observing or interacting with another creature outside combat, you can learn certain information about its capabilities compared to your own. The DM tells you if the creature is your equal, superior, or inferior in regard to two of the following characteristics of your choice:",
-											{
-												"type": "list",
-												"items": [
-													"Intelligence score",
-													"Wisdom score",
-													"Charisma score",
-													"Class levels (if any)"
-												]
-											},
-											"At the DM's option, you might also realize you know a piece of the creature's history or one of its personality traits, if it has any."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Misdirection",
-										"entries": [
-											"Beginning at 13th level, you can sometimes cause another creature to suffer an attack meant for you. When you are targeted by an attack while a creature within 5 feet of you is granting you cover against that attack, you can use your reaction to have the attack target that creature instead of you."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Soul of Deceit",
-										"entries": [
-											"Starting at 17th level, your thoughts can't be read by telepathy or other means, unless you allow it. You can present false thoughts by succeeding on a Charisma (Deception) check contested by the mind reader's Wisdom (Insight) check.",
-											"Additionally, no matter what you say, magic that would determine if you are telling the truth indicates you are being truthful if you so choose, and you can't be compelled to tell the truth by magic."
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "XGE",
-					"shortName": "Mastermind"
-				},
-				{
 					"name": "Scout",
 					"subclassFeatures": [
 						[
 							{
-								"name": "Scout",
+								"name": "偵查兵[Scout]",
 								"entries": [
-									"You are skilled in stealth and surviving far from the streets of a city, allowing you to scout ahead of your companions during expeditions. Rogues who embrace this archetype are at home in the wilderness and among barbarians and rangers, and many Scouts serve as the eyes and ears of war bands. Ambusher, spy, bounty hunter\u2014these are just a few of the roles that Scouts assume as they range the world.",
+									"你擅長在遠離城市和街道的地方潛行和生存，這讓你在探險中能離開你的同伴帶頭偵查。這一泛型的斥候許多都以荒野為家，與野蠻人和遊俠同行，也有許多斥候充當著戰爭地帶的眼睛和耳朵。伏擊兵，間諜，賞金獵人——這些只是斥候在世界範圍內所扮演的少數角色。",
 									{
 										"type": "entries",
-										"name": "Skirmisher",
+										"name": "散兵戰術[Skirmisher]",
 										"entries": [
-											"Starting at 3rd level, you are difficult to pin down during a fight. You can move up to half your speed as a reaction when an enemy ends its turn within 5 feet of you. This movement doesn't provoke opportunity attacks."
+											"從3級起，你在戰鬥中變得難以被壓制。當一個敵人在你周圍5英尺內結束其回合時，你可以以一個反應移動至多你速度的一半。此移動不會導致借機攻擊。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Survivalist",
+										"name": "生存專家[Survivalist]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you gain proficiency in the Nature and Survival skills if you don't already have it. Your proficiency bonus is doubled for any ability check you make that uses either of those proficiencies."
+											"當你在3級時選擇此範型時，你得到對於自然和生存技能的熟練。當使用上述熟練進行的任何屬性檢定中，你的熟練加值加倍。"
 										]
 									}
 								]
@@ -1473,9 +1176,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Superior Mobility",
+										"name": "優異靈活[Superior Mobility]",
 										"entries": [
-											"At 9th level, your walking speed increases by 10 feet. If you have a climbing or swimming speed, this increase applies to that speed as well."
+											"在9級時，你的行走速度增加10英尺。若你具有攀爬或遊泳速度，這個能力也會增加在這些速度上。"
 										]
 									}
 								]
@@ -1486,10 +1189,10 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Ambush Master",
+										"name": "突襲大師[Ambush Master]",
 										"entries": [
-											"Starting at 13th level, you excel at leading ambushes and acting first in a fight.",
-											"You have advantage on initiative rolls. In addition, the first creature you hit during the first round of a combat becomes easier for you and others to strike; attack rolls against that target have advantage until the start of your next turn."
+											"從13級起，你精通於引領突襲，在戰鬥中首先行動。",
+											"你在先攻檢定時具有優勢。此外，在第一輪戰鬥中你所命中的第一個生物對你和其他人而言會變得更容易打擊；直到你下一回合開始之前，所有對它進行的攻擊檢定具有優勢。"
 										]
 									}
 								]
@@ -1500,9 +1203,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Sudden Strike",
+										"name": "突襲打擊[Sudden Strike]",
 										"entries": [
-											"Starting at 17th level, you can strike with deadly speed. If you take the Attack action on your turn, you can make one additional attack as a bonus action. This attack can benefit from your Sneak Attack even if you have already used it this turn, but you can't use your Sneak Attack against the same target more than once in a turn."
+											"從17級起，你可以以致命的速度進行打擊。若你在你的回合進行攻擊動作，你可以以一個附贈動作進行一次額外的攻擊。此攻擊可以從你的偷襲中收益，即使你已經在此回合中使用了它，但是你不能在一回合中對同一目標偷襲一次以上。"
 										]
 									}
 								]
@@ -1517,23 +1220,23 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Swashbuckler",
+								"name": "遊蕩劍客 [Swashbuckler]",
 								"entries": [
-									"You focus your training on the art of the blade, relying on speed, elegance, and charm in equal parts. While some warriors are brutes clad in heavy armor, your method of fighting looks almost like a performance. Duelists and pirates typically belong to this archetype.",
-									"A Swashbuckler excels in single combat, and can fight with two weapons while safely darting away from an opponent.",
+									"你全身心投入劍術的訓練，一種兼顧了速度、優雅和魅力的劍術。對比其他被重甲包裹成粗蠻罐頭的戰士，你戰鬥的方式看起來更象在表演。掃蕩者、決鬥家和海盜是這類的典型。",
+									"遊蕩劍客擅長一對一的戰鬥，也精通於無所顧慮地使用雙武器攻擊對手，在那以後飛快地從他身邊逃脫。",
 									{
 										"type": "entries",
-										"name": "Fancy Footwork",
+										"name": "華麗舞步[Fancy Footwork]",
 										"entries": [
-											"When you choose this archetype at 3rd level, you learn how to land a strike and then slip away without reprisal. During your turn, if you make a melee attack against a creature, that creature can't make opportunity attacks against you for the rest of your turn."
+											"從3級起，你沖刺，攻擊，擺脫這些戰鬥中的動作就像一串模糊的身影。在你的回合，如果你對一個生物進行一次近身攻擊，那個生物在你回合剩下的時間內無法對你進行借機攻擊。"
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Rakish Audacity",
+										"name": "膽大行事[Rakish Audacity]",
 										"entries": [
-											"Starting at 3rd level, your confidence propels you into battle. You can give yourself a bonus to your initiative rolls equal to your Charisma modifier.",
-											"You also gain an additional way to use your Sneak Attack; you don't need advantage on the attack roll to use your Sneak Attack against a creature if you are within 5 feet of it, no other creatures are within 5 feet of you, and you don't have disadvantage on the attack roll. All the other rules for Sneak Attack still apply to you."
+											"從3級起，你萬無一失的自信驅使著你去戰鬥。你將你的魅力調整值加入你的先攻擲骰值。",
+											"你也可以通過一種額外的方式來使用偷襲攻擊：只要你在目標生物周圍5尺內，並且沒有其他生物在你5尺內，你的攻擊檢定也沒有劣勢，你就可以無需攻擊檢定的優勢對目標生物進行偷襲。其他所有關於偷襲的規則依然適用於你。"
 										]
 									}
 								]
@@ -1544,11 +1247,11 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Panache",
+										"name": "瀟灑氣質[Panache]",
 										"entries": [
-											"At 9th level, your charm becomes extraordinarily beguiling. As an action, you can make a Charisma (Persuasion) check contested by a creature's Wisdom (Insight) check. The creature must be able to hear you, and the two of you must share a language.",
-											"If you succeed on the check and the creature is hostile to you, it has disadvantage on attack rolls against targets other than you and can't make opportunity attacks against targets other than you. This effect lasts for 1 minute, until one of your companions attacks the target or affects it with a spell, or until you and the target are more than 60 feet apart.",
-											"If you succeed on the check and the creature isn't hostile to you, it is {@condition charmed} by you for 1 minute. While {@condition charmed}, it regards you as a friendly acquaintance. This effect ends immediately if you or your companions do anything harmful to it."
+											"從9級起，你的魅力變得更加迷人。你可以用一個動作進行一次魅力（遊說）檢定來對抗一個生物的感知（洞察）檢定。目標生物必須能聽到你的聲音，並且你們兩個必須會同一種語言。",
+											"如果那個生物是敵對的並且你的檢定成功，它對除你之外的其他目標攻擊取劣勢，並且不能對除你之外的目標進行借機攻擊。這個效果持續1分鐘，或你的隊友攻擊/用法術影響了這個目標，或你移動到遠離目標60尺外為止。",
+											"如果那個生物不是敵對的並且你的檢定成功，它被你魅惑1分鐘。當它被魅惑時，它認為你是一個友好的熟人。這個效果會在你或者你的隊友做出任何對他有害的行為之後立即結束。"
 										]
 									}
 								]
@@ -1559,9 +1262,9 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Elegant Maneuver",
+										"name": "優雅戰技[Elegant Maneuver]",
 										"entries": [
-											"Starting at 13th level, you can use a bonus action on your turn to gain advantage on the next Dexterity (Acrobatics) or Strength (Athletics) check you make during the same turn."
+											"從13級起，你可以輕松熟練的完成困難的戰技。你可以在你的回合用一個附贈動作來獲得在同一回合中下一個敏捷（特技動作）或力量（運動）檢定的優勢。"
 										]
 									}
 								]
@@ -1572,80 +1275,17 @@
 								"entries": [
 									{
 										"type": "entries",
-										"name": "Master Duelist",
+										"name": "決鬥大師[Master Duelist]",
 										"entries": [
-											"Beginning at 17th level, your mastery of the blade lets you turn failure into success in combat. If you miss with an attack roll, you can roll it again with advantage. Once you do so, you can't use this feature again until you finish a short or long rest."
+											"從17級起，你對劍術的精通使你可以扭轉戰鬥的勝負。如果你的一次攻擊失手，你可以選擇以優勢再投一次攻擊骰。一但你使用了這項能力，你直到完成一次短休息或長休息前不能再次使用它。"
 										]
 									}
 								]
 							}
 						]
 					],
-					"source": "XGE",
+					"source": "SCAG",
 					"shortName": "Swashbuckler"
-				},
-				{
-					"name": "Acrobat (Livestream)",
-					"subclassFeatures": [
-						[
-							{
-								"name": "Acrobat",
-								"entries": [
-									"{@i Transcribed on 2018-04-07. [Square bracketed text] denotes transcriber's annotations.}",
-									"Your archetype grants you features at 3rd level and then again at 9th, 13th, and 17th level.",
-									{
-										"type": "entries",
-										"name": "Aerial Artistry",
-										"entries": [
-											"Starting at 3rd level, you gain the ability {@i [to]} move with incredible speed, precision, and power, Few obstacles can prevent you from reaching your destination.",
-											"When you move, you can instead take two short movements by flying. Each movement is half your speed, and you must end each one on a solid object or {@i [the]} ground. If you do not, you fall and your movement ends."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Fearless Aerialist",
-										"entries": [
-											"Starting at 9th level, you no longer take damage from falling."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Unchained Agility",
-										"entries": [
-											"At 13th level, your agility, speed and flexibility allow you to escape from almost any danger. You gain the benefits of {@spell freedom of movement}."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"entries": [
-									{
-										"type": "entries",
-										"name": "Aerial Mastery",
-										"entries": [
-											"At 17th level your Aerial Artistry ability improves. When you move you can instead take four short movements by flying. {@i [Each short movement is still limited to half your speed, and between each movement you must still touch a solid object or the ground. If you do not, you fall and your movement ends.]}"
-										]
-									}
-								]
-							}
-						]
-					],
-					"source": "Stream",
-					"shortName": "Acrobat (Stream)"
 				}
 			],
 			"fluff": [

--- a/js/utils.js
+++ b/js/utils.js
@@ -1701,8 +1701,8 @@ SourceUtil = {
 		return (shortName !== undefined && shortName !== null && source !== undefined && source !== null) &&
 			(
 				(shortName === "Sun Soul" && source === SRC_SCAG) ||
-				(shortName === "Mastermind" && source === SRC_SCAG) ||
-				(shortName === "Swashbuckler" && source === SRC_SCAG) ||
+				//(shortName === "Mastermind" && source === SRC_SCAG) ||
+				//(shortName === "Swashbuckler" && source === SRC_SCAG) ||
 				(shortName === "Storm" && source === SRC_SCAG) ||
 				(shortName === "Deep Stalker Conclave" && source === SRC_UATRR)
 			);
@@ -2938,7 +2938,7 @@ function addListShowHide () {
 		<div class="col-xs-12" id="showsearch">
 			<button class="btn btn-block btn-default btn-xs" type="button">Show Search</button>
 			<br>
-		</div>	
+		</div>
 	`;
 
 	const toInjectHide = `


### PR DESCRIPTION
* 遊蕩者、詭術師範型

* 遊蕩者、刺客、策士範型

* 調整讓SCAG可以顯示在official，移除多餘的類別。

* 遊蕩者中文化，左邊邊攔先忽略

* 野蠻人中文化，左邊邊欄跳過

* 統一遊蕩者、野蠻人、吟遊詩人能力調整值增加的字，吟遊詩人基礎完成，學院尚未更新。